### PR TITLE
Restore .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+dist/** -diff linguist-generated


### PR DESCRIPTION
We accidentally lost the `.gitattributes` in #66!