### PR TITLE
[v1] Fix compatibility on macOS

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,7 +1,7 @@
 {
   "env": { "node": true },
   "parser": "@typescript-eslint/parser",
-  "parserOptions": { "ecmaVersion": 2020, "sourceType": "module" },
+  "parserOptions": { "ecmaVersion": 2021, "sourceType": "module" },
   "extends": [
     "eslint:recommended",
     "plugin:@typescript-eslint/eslint-recommended",
@@ -9,8 +9,7 @@
     "plugin:import/errors",
     "plugin:import/typescript",
     "plugin:import/warnings",
-    "plugin:prettier/recommended",
-    "prettier/@typescript-eslint"
+    "plugin:prettier/recommended"
   ],
   "plugins": ["@typescript-eslint", "simple-import-sort"],
   "settings": {

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -50,7 +50,11 @@ jobs:
         with:
           ocaml-version: ${{ matrix.ocaml-version }}
 
+      - run: opam install yaml --verbose --confirm-level=unsafe-yes --cli=2.1
+        if: runner.os == 'macOS'
+
       - run: opam depext yaml --install --verbose --yes
+        if: runner.os != 'macOS'
 
       - name: Check formatting
         run: yarn fmt:check

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Fixed
+
+- Stop installing `depext` package on macOS runners (opam is now at 2.1.0).
+
 ## [1.1.11]
 
 ### Changed

--- a/dist/index.js
+++ b/dist/index.js
@@ -5651,9 +5651,6 @@ function acquireOpamDarwin(version, customRepository) {
                     return [4 /*yield*/, (0,exec.exec)(__nccwpck_require__.ab + "install-ocaml-unix.sh", [version])];
                 case 4:
                     _a.sent();
-                    return [4 /*yield*/, (0,exec.exec)("opam", ["install", "-y", "depext"])];
-                case 5:
-                    _a.sent();
                     return [2 /*return*/];
             }
         });

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -89,7 +89,6 @@ async function acquireOpamDarwin(version: string, customRepository: string) {
   await exec("brew", ["install", "opam"]);
   await exec("opam", ["init", "--bare", "-yav", repository]);
   await exec(path.join(__dirname, "install-ocaml-unix.sh"), [version]);
-  await exec("opam", ["install", "-y", "depext"]);
 }
 
 export async function getOpam(


### PR DESCRIPTION
Homebrew now has opam 2.1 which means that the v1 action is failing.

Simplest workaround for now is just to remove the installation of the depext package.