### PR TITLE
Extends

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,4 +1,11 @@
 {
-  "proseWrap": "always",
-  "endOfLine": "auto"
+  "endOfLine": "auto",
+  "overrides": [
+    {
+      "files": "*.md",
+      "options": {
+        "proseWrap": "always"
+      }
+    }
+  ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Added
+
+- Added "extends" experimentally.
+
 ### Changed
 
 - Remove some hacks as `--no-depexts` is now used in CLI 2.0 mode from opam

--- a/README.md
+++ b/README.md
@@ -142,6 +142,116 @@ jobs:
       - run: opam exec -- dune runtest
 ```
 
+## Extends
+
+**STATUS: EXPERIMENTAL**
+
+Note: All extends are recommended to use in separate jobs run on
+`ubuntu-latest`.
+
+- [deploy-doc](#deploy-doc)
+- [lint-doc](#lint-doc)
+- [lint-fmt](#lint-fmt)
+- [lint-opam](#lint-opam)
+
+### deploy-doc
+
+```yml
+name: Deploy odoc
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  deploy-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml 4.13.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.13.x
+          dune-cache: true
+
+      - name: Deploy odoc to GitHub Pages
+        uses: ocaml/setup-ocaml/deploy-doc@v2
+```
+
+See [action.yml](deploy-doc/action.yml) for inputs.
+
+### lint-doc
+
+```yml
+jobs:
+  lint-doc:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml 4.13.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.13.x
+          dune-cache: true
+
+      - name: Lint doc
+        uses: ocaml/setup-ocaml/lint-doc@v2
+```
+
+See [action.yml](lint-doc/action.yml) for inputs.
+
+### lint-fmt
+
+Note: The ocamlformat configuration file must have the version of the
+ocamlformat used in the project.
+
+```yml
+jobs:
+  lint-fmt:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml 4.13.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.13.x
+          dune-cache: true
+
+      - name: Lint fmt
+        uses: ocaml/setup-ocaml/lint-fmt@v2
+```
+
+See [action.yml](lint-fmt/action.yml) for inputs.
+
+### lint-opam
+
+```yml
+jobs:
+  lint-opam:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Use OCaml 4.13.x
+        uses: ocaml/setup-ocaml@v2
+        with:
+          ocaml-compiler: 4.13.x
+          dune-cache: true
+
+      - name: Lint opam
+        uses: ocaml/setup-ocaml/lint-opam@v2
+```
+
+See [action.yml](lint-opam/action.yml) for inputs.
+
 ## Advanced Configurations
 
 See [Examples](examples.md) for more complex patterns.

--- a/action.yml
+++ b/action.yml
@@ -9,8 +9,7 @@ inputs:
     description: The OCaml compiler packages to initialise.
     required: true
   opam-repositories:
-    description:
-      The name and URL pair of the repository to fetch the packages from.
+    description: The name and URL pair of the repository to fetch the packages from.
     required: false
     default:
   opam-pin:

--- a/deploy-doc/action.yml
+++ b/deploy-doc/action.yml
@@ -1,0 +1,30 @@
+name: Deploy odoc
+description: Deploy odoc to GitHub Pages
+author: Sora Morimoto
+branding:
+  icon: package
+  color: orange
+inputs:
+  publish-dir:
+    description: The directory where the document is stored
+    required: false
+    default: _build/default/_doc/_html
+  destination-dir:
+    description: The subdirectory to deploy
+    required: false
+    default:
+runs:
+  using: composite
+  steps:
+    - run: opam install . --deps-only --with-doc
+      shell: bash
+    - run: opam depext --install doc
+      shell: bash
+    - run: opam exec -- dune build @doc
+      shell: bash
+    - name: Deploy odoc to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ github.token }}
+        publish_dir: ${{ inputs.publish-dir }}
+        destination_dir: ${{ inputs.destination-dir }}

--- a/lint-doc/action.yml
+++ b/lint-doc/action.yml
@@ -9,8 +9,7 @@ runs:
   steps:
     - run: opam depext --install conf-m4 dune 'odoc>=1.5.0'
       shell: bash
-    - run:
-        opam exec -- dune build @doc || (echo "dune build @doc failed"; exit 2)
+    - run: opam exec -- dune build @doc || (echo "dune build @doc failed"; exit 2)
       shell: bash
       env:
         ODOC_WARN_ERROR: true

--- a/lint-doc/action.yml
+++ b/lint-doc/action.yml
@@ -1,0 +1,16 @@
+name: Lint doc
+description: Check if your doc comments are error-and-warning-free
+author: Sora Morimoto
+branding:
+  icon: package
+  color: orange
+runs:
+  using: composite
+  steps:
+    - run: opam depext --install conf-m4 dune 'odoc>=1.5.0'
+      shell: bash
+    - run:
+        opam exec -- dune build @doc || (echo "dune build @doc failed"; exit 2)
+      shell: bash
+      env:
+        ODOC_WARN_ERROR: true

--- a/lint-fmt/action.yml
+++ b/lint-fmt/action.yml
@@ -1,0 +1,13 @@
+name: Lint fmt
+description: Check if your files are well-formatted
+author: Sora Morimoto
+branding:
+  icon: package
+  color: orange
+runs:
+  using: composite
+  steps:
+    - run: opam depext --install ocamlformat=$(awk -F = '/version/{print $2}' .ocamlformat)
+      shell: bash
+    - run: opam exec -- dune build @fmt
+      shell: bash

--- a/lint-opam/action.yml
+++ b/lint-opam/action.yml
@@ -1,0 +1,17 @@
+name: Lint opam
+description: Check if your dune and opam dependencies are consistent
+author: Sora Morimoto
+branding:
+  icon: package
+  color: orange
+runs:
+  using: composite
+  steps:
+    - run: opam install . --deps-only --with-test --with-doc
+      shell: bash
+    - run: opam depext --install opam-dune-lint
+      shell: bash
+    - run: opam lint
+      shell: bash
+    - run: opam exec -- opam-dune-lint
+      shell: bash


### PR DESCRIPTION
Add "extends" experimentally. The purpose is to provide more strong crash barriers for the user's OCaml project, and/or to encourage the document to be deployed. However, this PR is a sort of RFC, and it's not yet sure if it can actually be merged.