### PR TITLE
Print a proper error if the version not found in the .ocamlformat file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Fixed
+
+- Print a proper error if the version not found in the `.ocamlformat` file.
+
 ## [2.0.0-beta12]
 
 ### Fixed

--- a/lint-fmt/index.js
+++ b/lint-fmt/index.js
@@ -7375,6 +7375,9 @@ function getOcamlformatVersion() {
                 case 1:
                     config = _a.sent();
                     version = config.filter(function (line) { return line[0] === "version"; }).flat()[1];
+                    if (version === undefined) {
+                        throw new Error("Field version not found in .ocamlformat file: setting up your project to use the default profile and the OCamlFormat version you installed in .ocamlformat file is considered good practice");
+                    }
                     return [2 /*return*/, version];
             }
         });

--- a/src/lint-fmt/ocamlformat.ts
+++ b/src/lint-fmt/ocamlformat.ts
@@ -18,5 +18,8 @@ async function parse() {
 export async function getOcamlformatVersion() {
   const config = await parse();
   const version = config.filter((line) => line[0] === "version").flat()[1];
+  if (version === undefined) {
+    throw new Error("Field version not found in .ocamlformat file: setting up your project to use the default profile and the OCamlFormat version you installed in .ocamlformat file is considered good practice");
+  }
   return version;
 }

--- a/src/lint-fmt/ocamlformat.ts
+++ b/src/lint-fmt/ocamlformat.ts
@@ -19,7 +19,9 @@ export async function getOcamlformatVersion() {
   const config = await parse();
   const version = config.filter((line) => line[0] === "version").flat()[1];
   if (version === undefined) {
-    throw new Error("Field version not found in .ocamlformat file: setting up your project to use the default profile and the OCamlFormat version you installed in .ocamlformat file is considered good practice");
+    throw new Error(
+      "Field version not found in .ocamlformat file: setting up your project to use the default profile and the OCamlFormat version you installed in .ocamlformat file is considered good practice"
+    );
   }
   return version;
 }


### PR DESCRIPTION
print "version not found in .ocamlformat" if the version doesn't exist.

resolve #388 