### PR TITLE
Turn off git directory ownership check

### DIFF
--- a/src/setup-ocaml/opam.ts
+++ b/src/setup-ocaml/opam.ts
@@ -231,6 +231,7 @@ async function acquireOpamWindows() {
 }
 
 async function initializeOpamWindows() {
+  await exec("git", ["config", "--global", "--add", "safe.directory", "'*'"]);
   await exec("opam", [
     "init",
     "--auto-setup",


### PR DESCRIPTION
CI runners don't need this ownership check - disable it for the Cygwin git installation.

Fixes #479