### PR TITLE
Define `CLICOLOR_FORCE=1` env var in CI runs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+## Added
+
+- Define `CLICOLOR_FORCE=1` in CI runs.
+
 ## [2.0.6]
 
 ### Added

--- a/src/setup-ocaml/constants.ts
+++ b/src/setup-ocaml/constants.ts
@@ -82,3 +82,5 @@ const defaultRepository =
 export const OPAM_REPOSITORIES: [string, string][] = repositories_yaml
   ? Object.entries(repositories_yaml).reverse()
   : [["default", defaultRepository]];
+
+export const CLICOLOR_FORCE = "1";

--- a/src/setup-ocaml/constants.ts
+++ b/src/setup-ocaml/constants.ts
@@ -82,5 +82,3 @@ const defaultRepository =
 export const OPAM_REPOSITORIES: [string, string][] = repositories_yaml
   ? Object.entries(repositories_yaml).reverse()
   : [["default", defaultRepository]];
-
-export const CLICOLOR_FORCE = "1";

--- a/src/setup-ocaml/installer.ts
+++ b/src/setup-ocaml/installer.ts
@@ -142,6 +142,7 @@ export async function installer(): Promise<void> {
     core.exportVariable("DUNE_CACHE", "enabled");
     core.exportVariable("DUNE_CACHE_TRANSPORT", "direct");
   }
+  core.exportVariable("CLICOLOR_FORCE", "1");
   const fnames = await getOpamLocalPackages();
   if (fnames.length > 0) {
     if (OPAM_PIN) {


### PR DESCRIPTION
This env var is supported by some tools to force them to emit ANSI escape sequences corresponding to colors even if they detect that they're not running in tty, which is th case for CI jobs.

It is going to be supported in Dune 3.6.0, and perhaps other compilers and build systems.