### PR TITLE
Allow ocaml/opam-repository to be added to a opam-repositories without hash errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Don't install Cygwin's git or mercurial packages (reduces cache by ~90MB)
 
+### Fixed
+
+- Ensure ocaml/opam-repository can be added without getting hash errors.
+
 ## [2.0.10]
 
 ### Fixed


### PR DESCRIPTION
Currently if you add ocaml/opam-repository to the opam-repositories field, e.g.

```
  opam-repositories: |
    opam-repository-mingw: https://github.com/fdopen/opam-repository-mingw.git
    default: https://github.com/ocaml/opam-repository.git
```

The installation of the compiler will fail with:

```
 #=== ERROR while compiling ocaml-config.3 =====================================#
  Bad hash for D:/.opam/repo/default/packages/ocaml-config/ocaml-config.3/files/gen_ocaml_config.ml.in
```

This is something which is already fixed in opam 2.1 (see https://github.com/ocaml/opam/pull/3882). The proposed fix here works around the problem with the opam 2.0.10 binary from OCaml for Windows.

The problem is that the initial clone of the repository is checked out using Windows line-endings, which causes the hashing problem. The mechanism opam uses to _update_ repositories means this would not happen on subsequent `opam update` instructions. The workaround here is that setup-ocaml ensures that `core.autocrlf` is temporarily set to `input` while adding the repositories (it then restores whatever setting either the runner or workflow had specified afterwards).

This shim can be removed once setup-ocaml adopts opam 2.2 for the Windows runners.