### PR TITLE
Don't install Cygwin's git or mercurial

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Changed
+
+- Don't install Cygwin's git or mercurial packages (reduces cache by ~90MB)
+
 ## [2.0.10]
 
 ### Fixed

--- a/src/setup-ocaml/opam.ts
+++ b/src/setup-ocaml/opam.ts
@@ -180,10 +180,8 @@ async function setupCygwin() {
   const packages = [
     "curl",
     "diffutils",
-    "git",
     "m4",
     "make",
-    "mercurial",
     "mingw64-i686-gcc-core",
     "mingw64-i686-gcc-g++",
     "mingw64-x86_64-gcc-core",


### PR DESCRIPTION
The runners have the official Git and Mercurial Windows distributions installed. Avoiding installing the Cygwin packages reduces the cache tarball by roughly 90MB and is more consistent with opam 2.2's internal Cygwin installation (which expects both those packages to be installed externally).