### PR TITLE
Trim the output of `git-config`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to
 
 - Use ocaml-opam/opam-repository-mingw instead of fdopen/opam-repository-mingw.
 
+### Fixed
+
+- Fix in 2.0.11 for hashing caused an invalid git configuration to be written.
+
 ## [2.0.11]
 
 ### Changed

--- a/src/setup-ocaml/opam.ts
+++ b/src/setup-ocaml/opam.ts
@@ -350,7 +350,7 @@ export async function repositoryAddAll(
       if (autocrlf.exitCode !== 0) {
         restore_autocrlf = null; // Unset the value at the end
       } else {
-        restore_autocrlf = autocrlf.stdout;
+        restore_autocrlf = autocrlf.stdout.trim();
       }
     }
     await exec("git", ["config", "--global", "core.autocrlf", "input"]);

--- a/src/setup-ocaml/opam.ts
+++ b/src/setup-ocaml/opam.ts
@@ -346,7 +346,7 @@ export async function repositoryAddAll(
       ["config", "--global", "core.autocrlf"],
       { ignoreReturnCode: true }
     );
-    if (autocrlf.stdout !== "input") {
+    if (autocrlf.stdout.trim() !== "input") {
       if (autocrlf.exitCode !== 0) {
         restore_autocrlf = null; // Unset the value at the end
       } else {
@@ -380,7 +380,6 @@ async function repositoryList(): Promise<string[]> {
   let output = "";
   const opam = await findOpam();
   await exec(opam, ["repository", "list", "--all-switches", "--short"], {
-    silent: true,
     listeners: { stdout: (data) => (output += data.toString()) },
   });
   const result = output


### PR DESCRIPTION
#647 reads the output of `git config --global core.autocrlf` in order to restore it afterwards. It wasn't trimming the newline from stdout, so if the workflow _had_ changed the setting then it was restored with a `\n` character at the end which results in a corrupt git configuration.