### PR TITLE
Remove the pin on Cygwin version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Fixed
+
+- Cygwin pin to v3.4.6 workaround removed.
+
 ## [2.0.17]
 
 ### Fixed

--- a/packages/setup-ocaml/src/opam.ts
+++ b/packages/setup-ocaml/src/opam.ts
@@ -179,7 +179,6 @@ async function setupCygwin() {
   }
   const site = "https://mirrors.kernel.org/sourceware/cygwin";
   const packages = [
-    "cygwin=3.4.6-1",
     "curl",
     "diffutils",
     "m4",


### PR DESCRIPTION
~~Awaiting upstream re-release of tar 1.34 in Cygwin~~

tar [has been updated](https://cygwin.com/pipermail/cygwin/2023-June/253885.html) - the version pin is no longer required.