### PR TITLE
Fix v1 to run inside nektos/act

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -16915,6 +16915,9 @@ function getPlatform() {
 
 async function getLatestOpamRelease() {
     const semverRange = "<2.1.0";
+    if (!GITHUB_TOKEN) {
+        core.setFailed("GITHUB_TOKEN not set! For nektos/act, use act -s GITHUB_TOKEN=$(gh auth token)");
+    }
     const octokit = github.getOctokit(GITHUB_TOKEN);
     const { data: releases } = await octokit.rest.repos.listReleases({
         owner: "ocaml",
@@ -16949,6 +16952,7 @@ async function acquireOpamUnix(version, customRepository) {
     const { version: opamVersion, browserDownloadUrl } = await getLatestOpamRelease();
     const platform = getPlatform();
     const architecture = getArchitecture();
+    const disableSandboxing = [];
     const cachedPath = tool_cache.find("opam", version, architecture);
     if (cachedPath === "") {
         const downloadedPath = await tool_cache.downloadTool(browserDownloadUrl);
@@ -16964,8 +16968,15 @@ async function acquireOpamUnix(version, customRepository) {
         core.info("Added cached opam to the path");
     }
     if (platform === Platform.Linux) {
+        if (github.context.actor === "nektos/act") {
+            await (0,exec.exec)("sudo", ["apt-get", "update"]);
+            await (0,exec.exec)("sudo", ["apt-get", "--yes", "install", "rsync"]);
+            disableSandboxing.push("--disable-sandboxing");
+            core.exportVariable("OPAMROOTISOK", "1");
+        }
         await (0,exec.exec)("sudo", [
             "apt-get",
+            "--yes",
             "install",
             "bubblewrap",
             "darcs",
@@ -16979,7 +16990,13 @@ async function acquireOpamUnix(version, customRepository) {
         await (0,exec.exec)("brew", ["install", "darcs", "gpatch", "mercurial"]);
     }
     const repository = customRepository || "https://github.com/ocaml/opam-repository.git";
-    await (0,exec.exec)("opam", ["init", "--bare", "-yav", repository]);
+    await (0,exec.exec)("opam", [
+        "init",
+        "--bare",
+        ...disableSandboxing,
+        "-yav",
+        repository,
+    ]);
     await (0,exec.exec)(__nccwpck_require__.ab + "install-ocaml-unix.sh", [version]);
     await (0,exec.exec)("opam", ["install", "-y", "depext"]);
 }


### PR DESCRIPTION
@avsm Hello Anil! 

This PR is a small fix for the next release of `avsm/setup-ocaml@v1` to fix running it under `https://github.com/nektos/act`.

When `github.context.actor` is `"nektos/act"`:
- Add `apt-get update` before packages can be installed
- Use `--disable-sandboxing` for `opam init` (no `/dev/pts`)
- Set `OPAMROOTISOK` because of root in the act container
- Install missing `rsync` for getting sources using `rsync`

PS: I'll also submit setting `OPAMROOTISOK` should be added to `avsm/setup-ocaml@v2` as well (It already has `apt-get --yes` and installs `rsync`) and I'd also flip on --disable-sandboxing automatically when `nectos/act` is detected in v2.

PPS: `https://github.com/xapi-project/xen-api/blob/master/.github/workflows/main.yml` doesn't work with v2 yet and needs further digging (not for the lack of trying) thus I submit this for v1 first.