### PR TITLE
In nektos/act, disable sandboxing and set OPAMROOTISOK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to
 
 ## [unreleased]
 
+### Fixed
+
+- Fix opam calls to support testing GitHub actions in local containers
+  by using the act tool from https://github.com/nektos/act
+
 ## [2.0.18]
 
 ### Fixed

--- a/packages/setup-ocaml/src/opam.ts
+++ b/packages/setup-ocaml/src/opam.ts
@@ -138,7 +138,8 @@ async function initializeOpamUnix() {
     await installUnixSystemPackages();
   }
   const disableSandboxing = [];
-  if (OPAM_DISABLE_SANDBOXING) {
+  # Fix opam to run in act containers which have no /dev/pts for bubblewrap:
+  if (OPAM_DISABLE_SANDBOXING || github.context.actor === "nektos/act") {
     disableSandboxing.push("--disable-sandboxing");
   }
   await exec("opam", [


### PR DESCRIPTION
@avsm:

- Containers by `nektos/act` have no `/dev/pts` for `bubblewrap`, thus sandboxing in them fails.
- The default containers use root, thus set `OPAMROOTISOK` to silence `opam` user warnings.