### PR TITLE
Force dune to copy the cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Changed
+
+- Workaround dune cache hardlink failures by using copy mode always
+
 ## [2.0.18]
 
 ### Fixed

--- a/packages/setup-ocaml/src/installer.ts
+++ b/packages/setup-ocaml/src/installer.ts
@@ -90,6 +90,7 @@ export async function installer() {
     await installDune();
     core.exportVariable("DUNE_CACHE", "enabled");
     core.exportVariable("DUNE_CACHE_TRANSPORT", "direct");
+    core.exportVariable("DUNE_CACHE_STORAGE_MODE", "copy");
   }
   core.exportVariable("CLICOLOR_FORCE", "1");
   const fnames = await getOpamLocalPackages();


### PR DESCRIPTION
The hardlink mode is ineffective because two partitions may be used in CI, resulting in EXDEV errors when building.

Fixes #673 