### PR TITLE
Force post-process exit with `process.exit`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to
 
 ## [unreleased]
 
+### Fixed
+
+- Force post-process exit with `process.exit`.
+
 ## [2.1.1]
 
 ### Changed

--- a/packages/setup-ocaml/src/post.ts
+++ b/packages/setup-ocaml/src/post.ts
@@ -1,3 +1,6 @@
+/* eslint-disable unicorn/no-process-exit */
+import * as process from "node:process";
+
 import * as core from "@actions/core";
 
 import { saveDuneCache, saveOpamDownloadCache } from "./cache";
@@ -11,10 +14,12 @@ async function run() {
       await saveDuneCache();
     }
     await saveOpamDownloadCache();
+    process.exit(0);
   } catch (error) {
     if (error instanceof Error) {
       core.error(error.message);
     }
+    process.exit(1);
   }
 }
 


### PR DESCRIPTION
Since the release a few weeks ago, the action runner apparently no longer properly catches the exit of the post process. I don't know the root cause, but we can force exit the post process with `process.exit`.