### PR TITLE
Allow using msys2 instead of cygwin

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -37,6 +37,9 @@ inputs:
     description: The prefix of the cache keys.
     required: false
     default: v1
+  windows-environment:
+    description: Whether to use `cygwin` (default) or `msys2` for windows installs.
+    required: false
   github-token:
     description: DO NOT SET THIS.
     required: false

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -103618,7 +103618,7 @@ const ALLOW_PRERELEASE_OPAM = lib_core.getBooleanInput("allow-prerelease-opam", 
     required: false,
     trimWhitespace: true,
 });
-const WINDOWS_ENVIRONMENT = (() => {
+const constants_WINDOWS_ENVIRONMENT = (() => {
     const input = lib_core.getInput("windows-environment");
     if (!(constants_PLATFORM === "windows" || input === "")) {
         lib_core.error("windows-environment is only supported on windows");
@@ -103811,7 +103811,7 @@ async function restoreOpamCache() {
 }
 async function restoreOpamCaches() {
     return await core.group("Retrieve the opam cache", async () => {
-        const [opamCacheHit, cygwinCacheHit] = await Promise.all(PLATFORM === "windows"
+        const [opamCacheHit, cygwinCacheHit] = await Promise.all(PLATFORM === "windows" && WINDOWS_ENVIRONMENT === "cygwin"
             ? [restoreOpamCache(), restoreCygwinCache()]
             : [restoreOpamCache()]);
         return { opamCacheHit, cygwinCacheHit };

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -103712,6 +103712,7 @@ async function composeOpamCacheKeys() {
     const ocamlCompiler = await RESOLVED_COMPILER;
     const repositoryUrls = OPAM_REPOSITORIES.map(([_, value]) => value).join(",");
     const osInfo = await system.osInfo();
+    const msys2 = WINDOWS_ENVIRONMENT === "msys2" ? "msys2" : undefined;
     const plainKey = [
         PLATFORM,
         osInfo.release,
@@ -103720,7 +103721,9 @@ async function composeOpamCacheKeys() {
         ocamlCompiler,
         repositoryUrls,
         sandbox,
-    ].join(",");
+    ]
+        .concat(msys2 ?? [])
+        .join(",");
     const hash = crypto.createHash("sha256").update(plainKey).digest("hex");
     const key = `${CACHE_PREFIX}-setup-ocaml-opam-${hash}`;
     const restoreKeys = [key];

--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -103618,6 +103618,19 @@ const ALLOW_PRERELEASE_OPAM = lib_core.getBooleanInput("allow-prerelease-opam", 
     required: false,
     trimWhitespace: true,
 });
+const WINDOWS_ENVIRONMENT = (() => {
+    const input = lib_core.getInput("windows-environment");
+    if (!(constants_PLATFORM === "windows" || input === "")) {
+        lib_core.error("windows-environment is only supported on windows");
+    }
+    if (input === "msys2" || input === "cygwin") {
+        return input;
+    }
+    if (input !== "") {
+        lib_core.error("unrecognized value for windows-environment");
+    }
+    return "cygwin";
+})();
 const constants_CACHE_PREFIX = lib_core.getInput("cache-prefix", {
     required: false,
     trimWhitespace: true,

--- a/packages/setup-ocaml/src/cache.ts
+++ b/packages/setup-ocaml/src/cache.ts
@@ -17,6 +17,7 @@ import {
   OPAM_ROOT,
   PLATFORM,
   RESOLVED_COMPILER,
+  WINDOWS_ENVIRONMENT,
 } from "./constants.js";
 import { getLatestOpamRelease } from "./opam.js";
 import { getCygwinVersion } from "./windows.js";
@@ -177,7 +178,7 @@ async function restoreOpamCache() {
 export async function restoreOpamCaches() {
   return await core.group("Retrieve the opam cache", async () => {
     const [opamCacheHit, cygwinCacheHit] = await Promise.all(
-      PLATFORM === "windows"
+      PLATFORM === "windows" && WINDOWS_ENVIRONMENT === "cygwin"
         ? [restoreOpamCache(), restoreCygwinCache()]
         : [restoreOpamCache()],
     );

--- a/packages/setup-ocaml/src/cache.ts
+++ b/packages/setup-ocaml/src/cache.ts
@@ -50,6 +50,7 @@ async function composeOpamCacheKeys() {
   const ocamlCompiler = await RESOLVED_COMPILER;
   const repositoryUrls = OPAM_REPOSITORIES.map(([_, value]) => value).join(",");
   const osInfo = await system.osInfo();
+  const msys2 = WINDOWS_ENVIRONMENT === "msys2" ? "msys2" : undefined;
   const plainKey = [
     PLATFORM,
     osInfo.release,
@@ -58,7 +59,9 @@ async function composeOpamCacheKeys() {
     ocamlCompiler,
     repositoryUrls,
     sandbox,
-  ].join(",");
+  ]
+    .concat(msys2 ?? [])
+    .join(",");
   const hash = crypto.createHash("sha256").update(plainKey).digest("hex");
   const key = `${CACHE_PREFIX}-setup-ocaml-opam-${hash}`;
   const restoreKeys = [key];

--- a/packages/setup-ocaml/src/constants.ts
+++ b/packages/setup-ocaml/src/constants.ts
@@ -88,6 +88,23 @@ export const ALLOW_PRERELEASE_OPAM = core.getBooleanInput(
   },
 );
 
+export const WINDOWS_ENVIRONMENT: "cygwin" | "msys2" = (() => {
+  const input = core.getInput("windows-environment");
+
+  if (!(PLATFORM === "windows" || input === "")) {
+    core.error("windows-environment is only supported on windows");
+  }
+
+  if (input === "msys2" || input === "cygwin") {
+    return input;
+  }
+
+  if (input !== "") {
+    core.error("unrecognized value for windows-environment");
+  }
+  return "cygwin";
+})();
+
 export const CACHE_PREFIX = core.getInput("cache-prefix", {
   required: false,
   trimWhitespace: true,

--- a/packages/setup-ocaml/src/installer.ts
+++ b/packages/setup-ocaml/src/installer.ts
@@ -1,4 +1,5 @@
 import * as os from "node:os";
+// import * as path from "node:path";
 import * as process from "node:process";
 import * as core from "@actions/core";
 import { exec } from "@actions/exec";
@@ -9,6 +10,7 @@ import {
   saveOpamCache,
 } from "./cache.js";
 import {
+  CYGWIN_ROOT,
   CYGWIN_ROOT_BIN,
   DUNE_CACHE,
   DUNE_CACHE_ROOT,
@@ -17,6 +19,7 @@ import {
   OPAM_ROOT,
   PLATFORM,
   RESOLVED_COMPILER,
+  WINDOWS_ENVIRONMENT,
 } from "./constants.js";
 import { installDune } from "./dune.js";
 import {
@@ -27,7 +30,7 @@ import {
   setupOpam,
 } from "./opam.js";
 import { getOpamLocalPackages } from "./packages.js";
-import { setupCygwin } from "./windows.js";
+import { prepareMsys2, setupCygwin } from "./windows.js";
 
 export async function installer() {
   if (core.isDebug()) {
@@ -62,13 +65,24 @@ export async function installer() {
   }
   const { opamCacheHit, cygwinCacheHit } = await restoreOpamCaches();
   if (PLATFORM === "windows") {
-    await setupCygwin();
-    if (!cygwinCacheHit) {
-      await saveCygwinCache();
+    switch (WINDOWS_ENVIRONMENT) {
+      case "msys2": {
+        const msys2Root = await prepareMsys2();
+        await setupOpam(msys2Root);
+        break;
+      }
+      case "cygwin":
+        await setupCygwin();
+        if (!cygwinCacheHit) {
+          await saveCygwinCache();
+        }
+        core.addPath(CYGWIN_ROOT_BIN);
+        await setupOpam(CYGWIN_ROOT);
+        break;
     }
-    core.addPath(CYGWIN_ROOT_BIN);
+  } else {
+    await setupOpam();
   }
-  await setupOpam();
   await repositoryRemoveAll();
   await repositoryAddAll(OPAM_REPOSITORIES);
   const ocamlCompiler = await RESOLVED_COMPILER;

--- a/packages/setup-ocaml/src/opam.ts
+++ b/packages/setup-ocaml/src/opam.ts
@@ -8,7 +8,6 @@ import * as semver from "semver";
 import {
   ALLOW_PRERELEASE_OPAM,
   ARCHITECTURE,
-  CYGWIN_ROOT,
   GITHUB_TOKEN,
   OPAM_DISABLE_SANDBOXING,
   PLATFORM,
@@ -86,7 +85,7 @@ async function acquireOpam() {
   });
 }
 
-async function initializeOpam() {
+async function initializeOpam(prefix?: string) {
   await core.group("Initialise opam state", async () => {
     if (PLATFORM !== "windows") {
       try {
@@ -104,7 +103,7 @@ async function initializeOpam() {
     const extraOptions = [];
     if (PLATFORM === "windows") {
       extraOptions.push("--cygwin-local-install");
-      extraOptions.push(`--cygwin-location=${CYGWIN_ROOT}`);
+      extraOptions.push(`--cygwin-location=${prefix}`);
     }
     if (OPAM_DISABLE_SANDBOXING) {
       extraOptions.push("--disable-sandboxing");
@@ -119,9 +118,9 @@ async function initializeOpam() {
   });
 }
 
-export async function setupOpam() {
+export async function setupOpam(prefix?: string) {
   await acquireOpam();
-  await initializeOpam();
+  await initializeOpam(prefix);
 }
 
 export async function installOcaml(ocamlCompiler: string) {

--- a/packages/setup-ocaml/src/windows.ts
+++ b/packages/setup-ocaml/src/windows.ts
@@ -113,3 +113,58 @@ export async function setupCygwin() {
     await io.cp(setup, CYGWIN_ROOT);
   });
 }
+
+function getPacmanPath(msys2Root: string): string {
+  return path.join(msys2Root, "usr", "bin", "pacman");
+}
+
+async function testMsys2Installation(path: string): Promise<void> {
+  try {
+    await fs.access(path);
+  } catch {
+    throw new Error(`No msys2 installation found at: ${path}.`);
+  }
+}
+
+async function getMsys2Install(): Promise<[root: string, pacmanPath: string]> {
+  const msys2Root = process.env.MSYS2_ROOT;
+
+  // MSYS2_ROOT takes priority
+  if (msys2Root) {
+    await testMsys2Installation(msys2Root);
+    return [msys2Root, getPacmanPath(msys2Root)];
+  }
+  try {
+    // check for pacman from PATH
+    const pacmanPath = await io.which("pacman", true);
+    return [path.dirname(path.dirname(path.dirname(pacmanPath))), pacmanPath];
+  } catch {
+    // finally check the default msys directory
+    const defaultRoot = "C:\\msys64";
+    testMsys2Installation(defaultRoot);
+    return [defaultRoot, getPacmanPath(defaultRoot)];
+  }
+}
+
+export async function prepareMsys2(): Promise<string> {
+  return await core.group("Install needed Msys2 packages", async () => {
+    const [root, pacmanPath] = await getMsys2Install();
+    // core update
+    await exec(pacmanPath, ["-Syu", "--noconfirm"]);
+    // packages needed for opam
+    const packages = [
+      "curl",
+      "diffutils",
+      "m4",
+      "make",
+      "mingw-w64-i686-gcc",
+      "mingw-w64-x86_64-gcc",
+      "patch",
+      "perl",
+      "rsync",
+      "unzip",
+    ];
+    await exec(pacmanPath, ["-Syu", "--noconfirm", ...packages]);
+    return root;
+  });
+}


### PR DESCRIPTION
This patch provides support for using msys2 instead of cygwin as the environment for windows. It can be enabled with:

```yaml
with:
  windows-environment: msys2
```
Otherwise, it still defaults to cygwin.

It will use the msys2 installation specified as follows:
1) The one specified by the `MSYS2_ROOT` environment variable
2) If pacman is present in `PATH`, it will use the installation that the pacman binary belongs to.
3) Finally, if neither of those exist, then it uses the default installation path: `C:\msys64` (available in the windows image for github actions: https://github.com/actions/runner-images/blob/main/images/windows/Windows2022-Readme.md#msys2).

It does not cache the msys2 install, but it should be possible for setup-msys2 to handle that: https://github.com/msys2/setup-msys2.

This closes #846.