### PR TITLE
Add riscv64 support

### DIFF
--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -113399,6 +113399,9 @@ const constants_ARCHITECTURE = (() => {
         case "arm64": {
             return "arm64";
         }
+        case "riscv64": {
+            return "riscv64";
+        }
         case "s390x": {
             return "s390x";
         }

--- a/packages/setup-ocaml/src/constants.ts
+++ b/packages/setup-ocaml/src/constants.ts
@@ -13,6 +13,10 @@ export const ARCHITECTURE = (() => {
     case "arm64": {
       return "arm64";
     }
+    case "riscv64": {
+      return "riscv64";
+    }
+
     case "s390x": {
       return "s390x";
     }


### PR DESCRIPTION
https://github.com/apps/riscv-builders runs on real riscv64 machine

 I've tested ocaml 4.11 supported riscv64

![image](https://github.com/user-attachments/assets/b14b01ad-8f15-4c0d-9e28-59e31ea7a111)
