### PR TITLE
Set igncr using BASH_ENV instead of SHELLOPTS

### DIFF
--- a/dist/post/index.js
+++ b/dist/post/index.js
@@ -114768,6 +114768,7 @@ const constants_CYGWIN_MIRROR_ENCODED_URI = encodeURIComponent(CYGWIN_MIRROR).to
 // [HACK] https://github.com/ocaml/setup-ocaml/pull/55
 const constants_CYGWIN_ROOT = external_node_path_namespaceObject.join("D:", "cygwin");
 const CYGWIN_ROOT_BIN = external_node_path_namespaceObject.join(constants_CYGWIN_ROOT, "bin");
+const CYGWIN_BASH_ENV = external_node_path_namespaceObject.join(constants_CYGWIN_ROOT, "bash_env");
 const DUNE_CACHE_ROOT = (() => {
     const homeDir = external_node_os_.homedir();
     const xdgCacheHome = external_node_process_.env.XDG_CACHE_HOME;

--- a/packages/setup-ocaml/src/constants.ts
+++ b/packages/setup-ocaml/src/constants.ts
@@ -64,6 +64,8 @@ export const CYGWIN_ROOT = path.join("D:", "cygwin");
 
 export const CYGWIN_ROOT_BIN = path.join(CYGWIN_ROOT, "bin");
 
+export const CYGWIN_BASH_ENV = path.join(CYGWIN_ROOT, "bash_env");
+
 export const DUNE_CACHE_ROOT = (() => {
   const homeDir = os.homedir();
   const xdgCacheHome = process.env.XDG_CACHE_HOME;

--- a/packages/setup-ocaml/src/installer.ts
+++ b/packages/setup-ocaml/src/installer.ts
@@ -1,3 +1,4 @@
+import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as process from "node:process";
 import * as core from "@actions/core";
@@ -10,6 +11,7 @@ import {
   saveOpamCache,
 } from "./cache.js";
 import {
+  CYGWIN_BASH_ENV,
   CYGWIN_ROOT_BIN,
   DUNE_CACHE,
   DUNE_CACHE_ROOT,
@@ -47,7 +49,6 @@ export async function installer() {
     core.exportVariable("CYGWIN", "winsymlinks:native");
     core.exportVariable("HOME", process.env.USERPROFILE);
     core.exportVariable("MSYS", "winsymlinks:native");
-    core.exportVariable("SHELLOPTS", "igncr");
     await core.group(
       "Change the file system behaviour parameters",
       async () => {
@@ -70,6 +71,8 @@ export async function installer() {
     if (!cygwinCacheHit) {
       await saveCygwinCache();
     }
+    await fs.writeFile(CYGWIN_BASH_ENV, "set -o igncr");
+    core.exportVariable("BASH_ENV", CYGWIN_BASH_ENV);
     core.addPath(CYGWIN_ROOT_BIN);
   }
   await setupOpam();


### PR DESCRIPTION
Exporting SHELLOPTS changes the way all shell options behave, so it is better to use BASH_ENV instead. See #920 for more information.

Closes #920.