### PR TITLE
Work around failures on platforms where the number of files open at once is limited

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
   cache-prefix:
     description: The prefix of the cache keys.
     required: false
-    default: v1
+    default: v3
   github-token:
     description: DO NOT SET THIS.
     required: false


### PR DESCRIPTION
A number of users have been reporting failures on macOS such as:
```
 <><> Updating package repositories ><><><><><><><><><><><><><><><><><><><><>  🐫 
  [default] synchronised from git+https://github.com/ocaml/opam-repository.git
  [ERROR] Could not update repository "default": "/opt/homebrew/bin/gpatch -p1 -i /Users/runner/.opam/log/processed-patch-1950-3af777" exited with code 2
```
ever since https://github.com/ocaml/opam-repository/pull/27273 was merged.

Turns out the issue is a GNU Patch bug as it keeps open all the files modified by a given patch file and so it blows up on large patches when `ulimit -n` is too small, which is the case for github actions' macos-latest. It would've been possible to work around it using `ulimit -n` if GNU Patch had done a patch release in the last 7 years as another bug preventing the workaround was fixed upstream but never released (see https://savannah.gnu.org/bugs/?55797)

opam 2.4 should fix this issue for good as we were planning to move away from GNU Patch but sadly the release is few months away. In the meantime the only workaround i could think of is to change the key the github action cache associated with setup-ocaml for macos-latest so that everyone refetch opam-repository from scratch instead of using `opam update`.

If this fix works for you, a minor release of v3 would be highly appreciated so everyone is able to fix their CI simply by restarting the failed jobs.