### PR TITLE
Fix Cygwin installation path for Windows Server 2025

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -36,7 +36,7 @@ inputs:
   cache-prefix:
     description: The prefix of the cache keys.
     required: false
-    default: v3
+    default: v1
   github-token:
     description: DO NOT SET THIS.
     required: false

--- a/dist/post/index.cjs
+++ b/dist/post/index.cjs
@@ -97949,7 +97949,7 @@ var PLATFORM = (() => {
   }
 })();
 var GITHUB_WORKSPACE = process2.env.GITHUB_WORKSPACE ?? process2.cwd();
-var CYGWIN_ROOT = path.join("D:", "cygwin");
+var CYGWIN_ROOT = path.join("C:", "cygwin");
 var CYGWIN_ROOT_BIN = path.join(CYGWIN_ROOT, "bin");
 var CYGWIN_LOCAL_PACKAGE_DIR = path.join(CYGWIN_ROOT, "packages");
 var CYGWIN_BASH_ENV = path.join(CYGWIN_ROOT, "bash_env");
@@ -97959,13 +97959,13 @@ var DUNE_CACHE_ROOT = (() => {
     return path.join(xdgCacheHome, "dune");
   }
   if (PLATFORM === "windows") {
-    return path.join("D:", "dune");
+    return path.join("C:", "dune");
   }
   return path.join(os.homedir(), ".cache", "dune");
 })();
 var OPAM_ROOT = (() => {
   if (PLATFORM === "windows") {
-    return path.join("D:", ".opam");
+    return path.join("C:", ".opam");
   }
   return path.join(os.homedir(), ".opam");
 })();

--- a/packages/setup-ocaml/src/constants.ts
+++ b/packages/setup-ocaml/src/constants.ts
@@ -58,8 +58,7 @@ export const CYGWIN_MIRROR = "https://mirrors.kernel.org/sourceware/cygwin/";
 
 export const GITHUB_WORKSPACE = process.env.GITHUB_WORKSPACE ?? process.cwd();
 
-// [HACK] https://github.com/ocaml/setup-ocaml/pull/55
-export const CYGWIN_ROOT = path.join("D:", "cygwin");
+export const CYGWIN_ROOT = path.join("C:", "cygwin");
 
 export const CYGWIN_ROOT_BIN = path.join(CYGWIN_ROOT, "bin");
 
@@ -73,16 +72,14 @@ export const DUNE_CACHE_ROOT = (() => {
     return path.join(xdgCacheHome, "dune");
   }
   if (PLATFORM === "windows") {
-    // [HACK] https://github.com/ocaml/setup-ocaml/pull/55
-    return path.join("D:", "dune");
+    return path.join("C:", "dune");
   }
   return path.join(os.homedir(), ".cache", "dune");
 })();
 
 export const OPAM_ROOT = (() => {
   if (PLATFORM === "windows") {
-    // [HACK] https://github.com/ocaml/setup-ocaml/pull/55
-    return path.join("D:", ".opam");
+    return path.join("C:", ".opam");
   }
   return path.join(os.homedir(), ".opam");
 })();


### PR DESCRIPTION
Switch Cygwin installation from `D:` to `C:` drive due to `D:` drive removal in Windows Server 2025 runners. While this may impact performance compared to the previous `D:` drive optimization (PR #55), it ensures compatibility with the new runner environment.

Closes #990 