### PR TITLE
Clarify supported version syntax in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,15 @@ steps:
 
 The `ocaml-compiler` input supports the Semantic Versioning Specification, for more detailed examples please refer to the [documentation](https://github.com/npm/node-semver#ranges).
 
+When a version range is used (e.g., `5`, `5.4.x`), the highest matching version from the opam-repository is always selected.
+
+> [!WARNING]
+> Version numbers containing a dot **must be quoted** in YAML to avoid being parsed as floats. For example, an unquoted `5.10` is parsed as the float `5.1`, which would silently resolve to the latest `5.1.x` compiler instead of `5.10.x`. To be safe, always quote version values:
+>
+> ```yml
+> ocaml-compiler: "5.4"
+> ```
+
 > [!NOTE]
 > With the naughty exception of `4.02.2`, point releases are meant to be strictly compatible, so once we (OCaml dev team) release a new point release, upgrading should be a no-brainer.
 
@@ -160,9 +169,9 @@ Examples:
 
 - Exact package name: `ocaml-base-compiler.5.4.0`
 - Combine multiple packages: `ocaml-variants.5.4.0+options,ocaml-option-flambda,ocaml-option-musl,ocaml-option-static`
-- Major versions: `4`, `5`
-- Minor versions: `4.08`, `4.14`, `5.4`, `5.4.x`
-- More specific versions: `~4.02.2`, `5.4.0`
+- Major versions: `"4"`, `"5"`
+- Minor versions: `"4.08"`, `"4.14"`, `"5.4"`, `"5.4.x"`
+- More specific versions: `"~4.02.2"`, `"5.4.0"`
 
 ## Advanced Configurations
 


### PR DESCRIPTION
## Summary

- Document that the highest matching version from opam-repository is always selected when a version range is used
- Add a WARNING admonition about YAML float parsing (e.g. unquoted `5.10` is silently parsed as `5.1`)
- Quote version strings in the examples section to reinforce the recommended practice

Closes #954

## Test plan

- [x] Verify the WARNING and NOTE admonitions render correctly on GitHub
- [x] Confirm the inline YAML code block inside the WARNING renders properly