### PR TITLE
Support pre-release compiler version resolution

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -95240,45 +95240,63 @@ async function retrieveAllCompilerVersions() {
     repo: "opam-repository",
     path: "packages/ocaml-base-compiler"
   });
-  const versions = /* @__PURE__ */ new Set();
+  const versions = /* @__PURE__ */ new Map();
   if (Array.isArray(packages)) {
     for (const { path: p } of packages) {
       const basename7 = path15.basename(p);
-      const version3 = basename7.replace("ocaml-base-compiler.", "");
-      const parsed = semver5.parse(version3, { loose: true });
+      const opamVersion = basename7.replace("ocaml-base-compiler.", "");
+      const parsed = semver5.parse(opamVersion.replace("~", "-"), {
+        loose: true
+      });
       if (parsed !== null) {
-        const { major, minor: _minor, patch } = parsed;
-        const minor = major < 5 && _minor < 10 ? (
+        const minor = parsed.major < 5 && parsed.minor < 10 ? (
           // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
-          `0${_minor}`
+          `0${parsed.minor}`
         ) : (
           // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
-          _minor
+          parsed.minor
         );
-        const version4 = `${major}.${minor}.${patch}`;
-        versions.add(version4);
+        const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
+        const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
+        versions.set(semverVersion, opamVersion);
       }
     }
   }
-  return [...versions];
+  return versions;
 }
 async function resolveVersion(semverVersion) {
-  const compilerVersions = await retrieveAllCompilerVersions();
-  const matchedFullCompilerVersion = semver5.maxSatisfying(
-    compilerVersions,
-    semverVersion,
-    { loose: true }
-  );
-  if (matchedFullCompilerVersion === null) {
-    throw new Error(
-      `Could not find any OCaml compiler version matching '${semverVersion}' in the opam-repository. Please check if you specified a valid version number or version range.`
-    );
+  const versions = await retrieveAllCompilerVersions();
+  const semverVersions = versions.keys().toArray();
+  const stableMatch = semver5.maxSatisfying(semverVersions, semverVersion, {
+    loose: true
+  });
+  if (stableMatch !== null) {
+    const opamVersion = versions.get(stableMatch);
+    if (opamVersion !== void 0) {
+      return opamVersion;
+    }
   }
-  return matchedFullCompilerVersion;
+  const prereleaseMatch = semver5.maxSatisfying(semverVersions, semverVersion, {
+    loose: true,
+    includePrerelease: true
+  });
+  if (prereleaseMatch !== null) {
+    const opamVersion = versions.get(prereleaseMatch);
+    if (opamVersion !== void 0) {
+      return opamVersion;
+    }
+  }
+  throw new Error(
+    `Could not find any OCaml compiler version matching '${semverVersion}' in the opam-repository. Please check if you specified a valid version number or version range.`
+  );
 }
 var resolvedCompiler = (async () => {
-  const resolvedCompiler2 = isSemverValidRange(OCAML_COMPILER) ? `ocaml-base-compiler.${await resolveVersion(OCAML_COMPILER)}` : OCAML_COMPILER;
-  return resolvedCompiler2;
+  const semverInput = OCAML_COMPILER.replace("~", "-");
+  if (isSemverValidRange(semverInput)) {
+    const opamVersion = await resolveVersion(semverInput);
+    return `ocaml-base-compiler.${opamVersion}`;
+  }
+  return OCAML_COMPILER;
 })();
 
 // src/cache.ts

--- a/dist/post/index.cjs
+++ b/dist/post/index.cjs
@@ -93868,45 +93868,63 @@ async function retrieveAllCompilerVersions() {
     repo: "opam-repository",
     path: "packages/ocaml-base-compiler"
   });
-  const versions = /* @__PURE__ */ new Set();
+  const versions = /* @__PURE__ */ new Map();
   if (Array.isArray(packages)) {
     for (const { path: p } of packages) {
       const basename6 = path12.basename(p);
-      const version3 = basename6.replace("ocaml-base-compiler.", "");
-      const parsed = semver2.parse(version3, { loose: true });
+      const opamVersion = basename6.replace("ocaml-base-compiler.", "");
+      const parsed = semver2.parse(opamVersion.replace("~", "-"), {
+        loose: true
+      });
       if (parsed !== null) {
-        const { major, minor: _minor, patch } = parsed;
-        const minor = major < 5 && _minor < 10 ? (
+        const minor = parsed.major < 5 && parsed.minor < 10 ? (
           // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
-          `0${_minor}`
+          `0${parsed.minor}`
         ) : (
           // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
-          _minor
+          parsed.minor
         );
-        const version4 = `${major}.${minor}.${patch}`;
-        versions.add(version4);
+        const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
+        const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
+        versions.set(semverVersion, opamVersion);
       }
     }
   }
-  return [...versions];
+  return versions;
 }
 async function resolveVersion(semverVersion) {
-  const compilerVersions = await retrieveAllCompilerVersions();
-  const matchedFullCompilerVersion = semver2.maxSatisfying(
-    compilerVersions,
-    semverVersion,
-    { loose: true }
-  );
-  if (matchedFullCompilerVersion === null) {
-    throw new Error(
-      `Could not find any OCaml compiler version matching '${semverVersion}' in the opam-repository. Please check if you specified a valid version number or version range.`
-    );
+  const versions = await retrieveAllCompilerVersions();
+  const semverVersions = versions.keys().toArray();
+  const stableMatch = semver2.maxSatisfying(semverVersions, semverVersion, {
+    loose: true
+  });
+  if (stableMatch !== null) {
+    const opamVersion = versions.get(stableMatch);
+    if (opamVersion !== void 0) {
+      return opamVersion;
+    }
   }
-  return matchedFullCompilerVersion;
+  const prereleaseMatch = semver2.maxSatisfying(semverVersions, semverVersion, {
+    loose: true,
+    includePrerelease: true
+  });
+  if (prereleaseMatch !== null) {
+    const opamVersion = versions.get(prereleaseMatch);
+    if (opamVersion !== void 0) {
+      return opamVersion;
+    }
+  }
+  throw new Error(
+    `Could not find any OCaml compiler version matching '${semverVersion}' in the opam-repository. Please check if you specified a valid version number or version range.`
+  );
 }
 var resolvedCompiler = (async () => {
-  const resolvedCompiler2 = isSemverValidRange(OCAML_COMPILER) ? `ocaml-base-compiler.${await resolveVersion(OCAML_COMPILER)}` : OCAML_COMPILER;
-  return resolvedCompiler2;
+  const semverInput = OCAML_COMPILER.replace("~", "-");
+  if (isSemverValidRange(semverInput)) {
+    const opamVersion = await resolveVersion(semverInput);
+    return `ocaml-base-compiler.${opamVersion}`;
+  }
+  return OCAML_COMPILER;
 })();
 
 // src/cache.ts

--- a/packages/setup-ocaml/src/version.ts
+++ b/packages/setup-ocaml/src/version.ts
@@ -13,46 +13,63 @@ async function retrieveAllCompilerVersions() {
     repo: "opam-repository",
     path: "packages/ocaml-base-compiler",
   });
-  const versions = new Set<string>();
+  const versions = new Map<string, string>();
   if (Array.isArray(packages)) {
     for (const { path: p } of packages) {
       const basename = path.basename(p);
-      const version = basename.replace("ocaml-base-compiler.", "");
-      const parsed = semver.parse(version, { loose: true });
+      const opamVersion = basename.replace("ocaml-base-compiler.", "");
+      const parsed = semver.parse(opamVersion.replace("~", "-"), {
+        loose: true,
+      });
       if (parsed !== null) {
-        const { major, minor: _minor, patch } = parsed;
         const minor =
-          major < 5 && _minor < 10
+          parsed.major < 5 && parsed.minor < 10
             ? // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
-              `0${_minor}`
+              `0${parsed.minor}`
             : // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
-              _minor;
-        const version = `${major}.${minor}.${patch}`;
-        versions.add(version);
+              parsed.minor;
+        const prerelease =
+          parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
+        const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
+        versions.set(semverVersion, opamVersion);
       }
     }
   }
-  return [...versions];
+  return versions;
 }
 
 async function resolveVersion(semverVersion: string) {
-  const compilerVersions = await retrieveAllCompilerVersions();
-  const matchedFullCompilerVersion = semver.maxSatisfying(
-    compilerVersions,
-    semverVersion,
-    { loose: true },
-  );
-  if (matchedFullCompilerVersion === null) {
-    throw new Error(
-      `Could not find any OCaml compiler version matching '${semverVersion}' in the opam-repository. Please check if you specified a valid version number or version range.`,
-    );
+  const versions = await retrieveAllCompilerVersions();
+  const semverVersions = versions.keys().toArray();
+  const stableMatch = semver.maxSatisfying(semverVersions, semverVersion, {
+    loose: true,
+  });
+  if (stableMatch !== null) {
+    const opamVersion = versions.get(stableMatch);
+    if (opamVersion !== undefined) {
+      return opamVersion;
+    }
   }
-  return matchedFullCompilerVersion;
+  const prereleaseMatch = semver.maxSatisfying(semverVersions, semverVersion, {
+    loose: true,
+    includePrerelease: true,
+  });
+  if (prereleaseMatch !== null) {
+    const opamVersion = versions.get(prereleaseMatch);
+    if (opamVersion !== undefined) {
+      return opamVersion;
+    }
+  }
+  throw new Error(
+    `Could not find any OCaml compiler version matching '${semverVersion}' in the opam-repository. Please check if you specified a valid version number or version range.`,
+  );
 }
 
 export const resolvedCompiler = (async () => {
-  const resolvedCompiler = isSemverValidRange(OCAML_COMPILER)
-    ? `ocaml-base-compiler.${await resolveVersion(OCAML_COMPILER)}`
-    : OCAML_COMPILER;
-  return resolvedCompiler;
+  const semverInput = OCAML_COMPILER.replace("~", "-");
+  if (isSemverValidRange(semverInput)) {
+    const opamVersion = await resolveVersion(semverInput);
+    return `ocaml-base-compiler.${opamVersion}`;
+  }
+  return OCAML_COMPILER;
 })();


### PR DESCRIPTION
## Summary

- Semver ranges like `5.5` or `5.5.x` now automatically resolve to pre-release compiler versions (alpha, beta, RC) when no stable version is available
- Opam-style tilde versions like `5.5.0~alpha1` are also accepted and resolved correctly
- Stable versions are always preferred when they exist, preserving backward compatibility
- No additional repository configuration is required — opam >= 2.1 does not need the `ocaml-beta-repository` as the `ocaml-beta` dependency is gated with `{opam-version < "2.1.0"}`

### How it works

1. Convert opam's tilde pre-release separator (`~`) to semver's hyphen (`-`) during version parsing, so `5.5.0~alpha1` becomes `5.5.0-alpha1`
2. Store both semver and opam versions in a `Map<string, string>` (key: semver, value: opam) for deduplication and lookup
3. Two-pass resolution: first match stable versions only, then fall back to pre-release versions with `includePrerelease: true`
4. Return the original opam version string from the Map, avoiding lossy back-conversion

### Behaviour matrix

| Input | Stable exists? | Before | After |
|---|---|---|---|
| `5.4` | Yes (5.4.1) | `ocaml-base-compiler.5.4.1` | Same (unchanged) |
| `5.5.x` | No (alpha1 only) | Error | `ocaml-base-compiler.5.5.0~alpha1` |
| `5.5` | No (alpha1 only) | Error | `ocaml-base-compiler.5.5.0~alpha1` |
| `5.5.0~alpha1` | N/A | Error | `ocaml-base-compiler.5.5.0~alpha1` |
| `5` | Yes (5.4.1) | `ocaml-base-compiler.5.4.1` | Same (unchanged) |
| `5.4.x` | Yes + betas exist | `ocaml-base-compiler.5.4.1` | Same (stable preferred) |

### Why two passes are necessary

A single pass with `includePrerelease: true` would cause `5.x` to resolve to `5.5.0-alpha1` instead of the stable `5.4.0`, because semver considers `5.5.0-alpha1 > 5.4.0`. The two-pass approach ensures stable versions are always preferred for broad ranges.

Closes #232

## Test plan

- [ ] Verify `ocaml-compiler: "5.5"` resolves to `ocaml-base-compiler.5.5.0~alpha1`
- [ ] Verify `ocaml-compiler: "5.5.0~alpha1"` resolves to `ocaml-base-compiler.5.5.0~alpha1`
- [ ] Verify `ocaml-compiler: "5.3"` still resolves to the latest stable 5.3.x
- [ ] Verify `ocaml-compiler: "4.14.x"` still resolves to the latest stable 4.14.x
- [ ] Verify `ocaml-compiler: "5"` resolves to latest stable 5.x (not a pre-release)