### PR TITLE
Adopt ES2025 Iterator Helpers where they improve readability

### DIFF
--- a/analysis/dist/index.cjs
+++ b/analysis/dist/index.cjs
@@ -46494,12 +46494,8 @@ function parseDependencies(cache, dependencies) {
     if (cache.hasPackage(purl)) {
       return cache.package(purl);
     }
-    const pkgs = /* @__PURE__ */ new Set();
-    if (dependency.dependencies.length > 0) {
-      for (const pkg of parseDependencies(cache, dependency.dependencies))
-        pkgs.add(pkg);
-    }
-    return cache.package(purl).dependsOnPackages([...pkgs]);
+    const pkgs = new Set(parseDependencies(cache, dependency.dependencies));
+    return cache.package(purl).dependsOnPackages(pkgs.values().toArray());
   });
   return packages;
 }

--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -95234,35 +95234,35 @@ var semver5 = __toESM(require_semver2(), 1);
 function isSemverValidRange(semverVersion) {
   return semver5.validRange(semverVersion, { loose: true }) !== null;
 }
+function parseCompilerVersion(packagePath) {
+  const opamVersion = path15.basename(packagePath).replace("ocaml-base-compiler.", "");
+  const parsed = semver5.parse(opamVersion.replace("~", "-"), { loose: true });
+  if (parsed === null) {
+    return void 0;
+  }
+  const minor = parsed.major < 5 && parsed.minor < 10 ? (
+    // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
+    `0${parsed.minor}`
+  ) : (
+    // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
+    parsed.minor
+  );
+  const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
+  const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
+  return [semverVersion, opamVersion];
+}
 async function retrieveAllCompilerVersions() {
   const { data: packages } = await octokit.rest.repos.getContent({
     owner: "ocaml",
     repo: "opam-repository",
     path: "packages/ocaml-base-compiler"
   });
-  const versions = /* @__PURE__ */ new Map();
-  if (Array.isArray(packages)) {
-    for (const { path: p } of packages) {
-      const basename7 = path15.basename(p);
-      const opamVersion = basename7.replace("ocaml-base-compiler.", "");
-      const parsed = semver5.parse(opamVersion.replace("~", "-"), {
-        loose: true
-      });
-      if (parsed !== null) {
-        const minor = parsed.major < 5 && parsed.minor < 10 ? (
-          // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
-          `0${parsed.minor}`
-        ) : (
-          // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
-          parsed.minor
-        );
-        const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
-        const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
-        versions.set(semverVersion, opamVersion);
-      }
-    }
+  if (!Array.isArray(packages)) {
+    return /* @__PURE__ */ new Map();
   }
-  return versions;
+  return new Map(
+    packages.values().map(({ path: path17 }) => parseCompilerVersion(path17)).filter((entry) => entry !== void 0)
+  );
 }
 async function resolveVersion(semverVersion) {
   const versions = await retrieveAllCompilerVersions();

--- a/dist/post/index.cjs
+++ b/dist/post/index.cjs
@@ -93862,35 +93862,35 @@ var semver2 = __toESM(require_semver2(), 1);
 function isSemverValidRange(semverVersion) {
   return semver2.validRange(semverVersion, { loose: true }) !== null;
 }
+function parseCompilerVersion(packagePath) {
+  const opamVersion = path12.basename(packagePath).replace("ocaml-base-compiler.", "");
+  const parsed = semver2.parse(opamVersion.replace("~", "-"), { loose: true });
+  if (parsed === null) {
+    return void 0;
+  }
+  const minor = parsed.major < 5 && parsed.minor < 10 ? (
+    // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
+    `0${parsed.minor}`
+  ) : (
+    // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
+    parsed.minor
+  );
+  const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
+  const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
+  return [semverVersion, opamVersion];
+}
 async function retrieveAllCompilerVersions() {
   const { data: packages } = await octokit.rest.repos.getContent({
     owner: "ocaml",
     repo: "opam-repository",
     path: "packages/ocaml-base-compiler"
   });
-  const versions = /* @__PURE__ */ new Map();
-  if (Array.isArray(packages)) {
-    for (const { path: p } of packages) {
-      const basename6 = path12.basename(p);
-      const opamVersion = basename6.replace("ocaml-base-compiler.", "");
-      const parsed = semver2.parse(opamVersion.replace("~", "-"), {
-        loose: true
-      });
-      if (parsed !== null) {
-        const minor = parsed.major < 5 && parsed.minor < 10 ? (
-          // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
-          `0${parsed.minor}`
-        ) : (
-          // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
-          parsed.minor
-        );
-        const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
-        const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
-        versions.set(semverVersion, opamVersion);
-      }
-    }
+  if (!Array.isArray(packages)) {
+    return /* @__PURE__ */ new Map();
   }
-  return versions;
+  return new Map(
+    packages.values().map(({ path: path13 }) => parseCompilerVersion(path13)).filter((entry) => entry !== void 0)
+  );
 }
 async function resolveVersion(semverVersion) {
   const versions = await retrieveAllCompilerVersions();

--- a/lint-fmt/dist/index.cjs
+++ b/lint-fmt/dist/index.cjs
@@ -19797,6 +19797,10 @@ function convertToUnix(str) {
 }
 
 // src/ocamlformat.ts
+function parseKeyValue(line) {
+  const [key = "", value = ""] = line.split("=").map((s) => s.trim());
+  return [key, value];
+}
 async function parse() {
   const githubWorkspace = process2.env.GITHUB_WORKSPACE ?? process2.cwd();
   const fpath = path4.join(githubWorkspace, ".ocamlformat");
@@ -19805,9 +19809,7 @@ async function parse() {
     const buf = await import_node_fs.promises.readFile(fpath);
     const str = buf.toString();
     const normalisedStr = convertToUnix(str);
-    const kv = normalisedStr.split("\n").map((line) => line.split("=").map((str2) => str2.trim()));
-    const config = Object.fromEntries(kv);
-    return config;
+    return new Map(normalisedStr.split("\n").values().map(parseKeyValue));
   } catch {
     return;
   }
@@ -19818,8 +19820,9 @@ async function retrieveOcamlformatVersion() {
     warning(".ocamlformat file not found");
     return;
   }
-  if (config.version) {
-    return config.version;
+  const version = config.get("version");
+  if (version) {
+    return version;
   }
   warning(
     "No ocamlformat version found in .ocamlformat file. It's recommended to specify the version in your .ocamlformat file for better consistency."

--- a/packages/analysis/src/opam-detector.ts
+++ b/packages/analysis/src/opam-detector.ts
@@ -45,12 +45,8 @@ function parseDependencies(
     if (cache.hasPackage(purl)) {
       return cache.package(purl);
     }
-    const pkgs = new Set<Package>();
-    if (dependency.dependencies.length > 0) {
-      for (const pkg of parseDependencies(cache, dependency.dependencies))
-        pkgs.add(pkg);
-    }
-    return cache.package(purl).dependsOnPackages([...pkgs]);
+    const pkgs = new Set(parseDependencies(cache, dependency.dependencies));
+    return cache.package(purl).dependsOnPackages(pkgs.values().toArray());
   });
   return packages;
 }

--- a/packages/lint-fmt/src/ocamlformat.ts
+++ b/packages/lint-fmt/src/ocamlformat.ts
@@ -4,6 +4,11 @@ import * as process from "node:process";
 import * as core from "@actions/core";
 import { convertToUnix } from "./compat.js";
 
+function parseKeyValue(line: string): [string, string] {
+  const [key = "", value = ""] = line.split("=").map((s) => s.trim());
+  return [key, value];
+}
+
 async function parse() {
   const githubWorkspace = process.env.GITHUB_WORKSPACE ?? process.cwd();
   const fpath = path.join(githubWorkspace, ".ocamlformat");
@@ -12,11 +17,7 @@ async function parse() {
     const buf = await fs.readFile(fpath);
     const str = buf.toString();
     const normalisedStr = convertToUnix(str);
-    const kv = normalisedStr
-      .split("\n")
-      .map((line) => line.split("=").map((str) => str.trim()));
-    const config: Record<string, string> = Object.fromEntries(kv);
-    return config;
+    return new Map(normalisedStr.split("\n").values().map(parseKeyValue));
   } catch {
     return;
   }
@@ -28,8 +29,9 @@ export async function retrieveOcamlformatVersion() {
     core.warning(".ocamlformat file not found");
     return;
   }
-  if (config.version) {
-    return config.version;
+  const version = config.get("version");
+  if (version) {
+    return version;
   }
   core.warning(
     "No ocamlformat version found in .ocamlformat file. It's recommended to specify the version in your .ocamlformat file for better consistency.",

--- a/packages/setup-ocaml/src/version.ts
+++ b/packages/setup-ocaml/src/version.ts
@@ -7,35 +7,43 @@ function isSemverValidRange(semverVersion: string) {
   return semver.validRange(semverVersion, { loose: true }) !== null;
 }
 
+function parseCompilerVersion(
+  packagePath: string,
+): readonly [string, string] | undefined {
+  const opamVersion = path
+    .basename(packagePath)
+    .replace("ocaml-base-compiler.", "");
+  const parsed = semver.parse(opamVersion.replace("~", "-"), { loose: true });
+  if (parsed === null) {
+    return undefined;
+  }
+  const minor =
+    parsed.major < 5 && parsed.minor < 10
+      ? // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
+        `0${parsed.minor}`
+      : // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
+        parsed.minor;
+  const prerelease =
+    parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
+  const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
+  return [semverVersion, opamVersion] as const;
+}
+
 async function retrieveAllCompilerVersions() {
   const { data: packages } = await octokit.rest.repos.getContent({
     owner: "ocaml",
     repo: "opam-repository",
     path: "packages/ocaml-base-compiler",
   });
-  const versions = new Map<string, string>();
-  if (Array.isArray(packages)) {
-    for (const { path: p } of packages) {
-      const basename = path.basename(p);
-      const opamVersion = basename.replace("ocaml-base-compiler.", "");
-      const parsed = semver.parse(opamVersion.replace("~", "-"), {
-        loose: true,
-      });
-      if (parsed !== null) {
-        const minor =
-          parsed.major < 5 && parsed.minor < 10
-            ? // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
-              `0${parsed.minor}`
-            : // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
-              parsed.minor;
-        const prerelease =
-          parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
-        const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;
-        versions.set(semverVersion, opamVersion);
-      }
-    }
+  if (!Array.isArray(packages)) {
+    return new Map<string, string>();
   }
-  return versions;
+  return new Map(
+    packages
+      .values()
+      .map(({ path }) => parseCompilerVersion(path))
+      .filter((entry) => entry !== undefined),
+  );
 }
 
 async function resolveVersion(semverVersion: string) {


### PR DESCRIPTION
## Summary

- **`version.ts`**: Extract `parseCompilerVersion` helper; build the compiler version `Map` declaratively with `.values().map().filter()` instead of an imperative `for…of` loop with `.set()`.
- **`ocamlformat.ts`**: Replace `Object.fromEntries` + intermediate array with `new Map(…values().map(parseKeyValue))` and a small `parseKeyValue` helper that removes the `as` cast.
- **`opam-detector.ts`**: Construct the `Set` directly from the recursive call and convert back with `.values().toArray()`.

All three changes leverage `Iterator.prototype.map`, `.filter`, and `.toArray` — available via the `ESNext.Iterator` lib that `@tsconfig/node24` already provides.

## Test plan

- [x] `yarn typecheck` passes across all five packages
- [x] `yarn build` succeeds with no regressions
- [x] Verify the action runs correctly on a test workflow