### PR TITLE
Include Visual Studio version in MSVC opam cache key

### DIFF
--- a/dist/index.cjs
+++ b/dist/index.cjs
@@ -95314,6 +95314,14 @@ async function composeDuneCacheKeys() {
   debug(`dune cache key: ${plainKey}`);
   return { key, restoreKeys };
 }
+async function getMsvcVersion() {
+  const { stdout } = await getExecOutput(
+    "vswhere",
+    ["-latest", "-property", "installationVersion"],
+    { silent: true }
+  );
+  return stdout.trim();
+}
 async function composeOpamCacheKeys() {
   const { version: opamVersion } = await latestOpamRelease;
   const sandbox = OPAM_DISABLE_SANDBOXING ? "nosandbox" : "sandbox";
@@ -95332,6 +95340,10 @@ async function composeOpamCacheKeys() {
   if (PLATFORM === "windows") {
     components.push(WINDOWS_ENVIRONMENT);
     components.push(WINDOWS_COMPILER);
+    if (WINDOWS_COMPILER === "msvc") {
+      const msvcVersion = await getMsvcVersion();
+      components.push(msvcVersion);
+    }
   }
   const plainKey = components.join();
   const hash = crypto5.createHash("sha256").update(plainKey).digest("hex");

--- a/packages/setup-ocaml/src/cache.ts
+++ b/packages/setup-ocaml/src/cache.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import type { DownloadOptions } from "@actions/cache";
 import * as cache from "@actions/cache";
 import * as core from "@actions/core";
-import { exec } from "@actions/exec";
+import { exec, getExecOutput } from "@actions/exec";
 import * as github from "@actions/github";
 import { backOff } from "exponential-backoff";
 import * as system from "systeminformation";
@@ -37,6 +37,15 @@ async function composeDuneCacheKeys() {
   return { key, restoreKeys };
 }
 
+async function getMsvcVersion() {
+  const { stdout } = await getExecOutput(
+    "vswhere",
+    ["-latest", "-property", "installationVersion"],
+    { silent: true },
+  );
+  return stdout.trim();
+}
+
 async function composeOpamCacheKeys() {
   const { version: opamVersion } = await latestOpamRelease;
   const sandbox = OPAM_DISABLE_SANDBOXING ? "nosandbox" : "sandbox";
@@ -55,6 +64,10 @@ async function composeOpamCacheKeys() {
   if (PLATFORM === "windows") {
     components.push(WINDOWS_ENVIRONMENT);
     components.push(WINDOWS_COMPILER);
+    if (WINDOWS_COMPILER === "msvc") {
+      const msvcVersion = await getMsvcVersion();
+      components.push(msvcVersion);
+    }
   }
   const plainKey = components.join();
   const hash = crypto.createHash("sha256").update(plainKey).digest("hex");


### PR DESCRIPTION
## Summary

- Include the Visual Studio installation version (obtained via `vswhere`) in the opam cache key when using the MSVC compiler on Windows
- Prevents wasteful recompilation of the entire compiler chain (11 packages) when the MSVC toolchain is updated on the runner between cache save and restore
- A toolchain update now produces a cache miss and a clean install, rather than a cache hit followed by a costly partial recompilation triggered by opam detecting changes to `msvcrt.lib`

## Test plan

- [x] Verify that MSVC CI jobs pass on both Cygwin and MSYS2 environments
- [x] Confirm the cache key includes the VS installation version in debug logs
- [x] Validate that a runner with an unchanged VS version still gets a cache hit