### PR TITLE
Refine Windows columns in OCaml Compiler Support Matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,11 +88,13 @@ When using GitHub-hosted runners, specifying compiler version `4` or `5` should 
 
 #### x86 64 bits
 
-| Version           | Ubuntu             | macOS              | Windows            |
-| ----------------- | ------------------ | ------------------ | ------------------ |
-| >= 4.13           | :white_check_mark: | :white_check_mark: | :white_check_mark: |
-| >= 4.02 & <= 4.12 | :white_check_mark: | :white_check_mark: | :x:                |
-| <= 4.01           | :white_check_mark: | :white_check_mark: | :x:                |
+| Version           | Ubuntu             | macOS              | Windows (MinGW-w64) | Windows (MSVC)     |
+| ----------------- | ------------------ | ------------------ | ------------------- | ------------------ |
+| >= 5.3            | :white_check_mark: | :white_check_mark: | :white_check_mark:  | :white_check_mark: |
+| >= 5.0 & <= 5.2   | :white_check_mark: | :white_check_mark: | :white_check_mark:  | :x:                |
+| >= 4.13 & <= 4.14 | :white_check_mark: | :white_check_mark: | :white_check_mark:  | :white_check_mark: |
+| >= 4.02 & <= 4.12 | :white_check_mark: | :white_check_mark: | :x:                 | :x:                |
+| <= 4.01           | :white_check_mark: | :white_check_mark: | :x:                 | :x:                |
 
 #### ARM 64 bits
 


### PR DESCRIPTION
## Summary

- Split the single "Windows" column in the x86 64-bit support matrix into "Windows (MinGW-w64)" and "Windows (MSVC)" to properly document the per-toolchain support status.
- The MSVC port was removed in OCaml 5.0 (multicore runtime required C11 atomics unavailable in older Visual Studio versions) and restored in 5.3 (Visual Studio 2022 17.8+ provides C11 atomics). This gap is now clearly visible in the matrix.

## Test plan

- [x] Verify the rendered table displays correctly on GitHub.
- [x] Confirm the MSVC support status aligns with the [official OCaml Windows documentation](https://github.com/ocaml/ocaml/blob/trunk/README.win32.adoc).