### PR TITLE
Split test job into per-platform jobs

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
   schedule:
-    # Prime the caches every Monday
     - cron: 0 1 * * MON
 
 permissions: read-all
@@ -23,64 +22,70 @@ jobs:
         run: yarn lint
       - if: always()
         run: yarn typecheck
-      - name: Ensure dist directory is up-to-date
-        if: always()
+      - if: always()
+        name: Ensure dist directory is up-to-date
         run: yarn build && git diff --exit-code --ignore-cr-at-eol
 
-  test:
-    name: Test
+  ubuntu:
+    name: Ubuntu
     needs: hygiene
+    runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - macos-latest
-        ocaml-compiler:
-          - "5.4"
         allow-prerelease-opam:
+          - true
           - false
-        include:
-          - os: ubuntu-latest
-            ocaml-compiler: ocaml-variants.5.4.0+options,ocaml-option-flambda
-            allow-prerelease-opam: false
-          - os: ubuntu-latest
-            ocaml-compiler: "5.4"
-            allow-prerelease-opam: true
-          - os: windows-latest
-            ocaml-compiler: "5.4"
-            allow-prerelease-opam: false
-            windows-environment: cygwin
-          - os: windows-latest
-            ocaml-compiler: "5.4"
-            allow-prerelease-opam: false
-            windows-environment: msys2
-          - os: windows-latest
-            ocaml-compiler: "5.4"
-            allow-prerelease-opam: false
-            windows-environment: cygwin
-            windows-compiler: msvc
-          - os: windows-latest
-            ocaml-compiler: "5.4"
-            allow-prerelease-opam: false
-            windows-environment: msys2
-            windows-compiler: msvc
-    runs-on: ${{ matrix.os }}
+      fail-fast: false
     steps:
       - name: Checkout tree
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-      - name: Set-up OCaml ${{ matrix.ocaml-compiler }}
+      - name: Set-up OCaml 5.4
         uses: ./
         with:
-          ocaml-compiler: ${{ matrix.ocaml-compiler }}
+          ocaml-compiler: "5.4"
           allow-prerelease-opam: ${{ matrix.allow-prerelease-opam }}
-          windows-environment: ${{ matrix.windows-environment || 'cygwin' }}
-          windows-compiler: ${{ matrix.windows-compiler || 'mingw' }}
+      - run: opam install ssl
+
+  macos:
+    name: macOS
+    needs: hygiene
+    runs-on: macos-latest
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set-up OCaml 5.4
+        uses: ./
+        with:
+          ocaml-compiler: "5.4"
+      - run: opam install ssl
+
+  windows:
+    name: Windows
+    needs: hygiene
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        windows-compiler:
+          - mingw
+          - msvc
+        windows-environment:
+          - cygwin
+          - msys2
+      fail-fast: false
+    steps:
+      - name: Checkout tree
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - name: Set-up OCaml 5.4
+        uses: ./
+        with:
+          ocaml-compiler: "5.4"
+          windows-compiler: ${{ matrix.windows-compiler }}
+          windows-environment: ${{ matrix.windows-environment }}
       - run: opam install ssl
         continue-on-error: ${{ matrix.windows-compiler == 'msvc' }}
 
-  test-container:
-    name: Test on a container in a GitHub runner
+  container:
+    name: Container
     needs: hygiene
     runs-on: ubuntu-latest
     container:

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -20,16 +20,16 @@ jobs:
   deploy-odoc:
     name: Deploy odoc to GitHub Pages
 
-    environment:
-      name: github-pages
-      url: ${{ steps.deployment.outputs.page_url }}
-
     permissions:
       contents: read
       id-token: write
       pages: write
 
     runs-on: ubuntu-latest
+
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
 
     steps:
       - name: Checkout tree
@@ -54,8 +54,8 @@ jobs:
         with:
           path: _build/default/_doc/_html
 
-      - name: Deploy odoc to GitHub Pages
-        id: deployment
+      - id: deployment
+        name: Deploy odoc to GitHub Pages
         uses: actions/deploy-pages@v4
 ```
 
@@ -112,16 +112,16 @@ steps:
 ## Using with [Containers](https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idcontainer)
 
 ```yml
+runs-on: ubuntu-latest
+
+container: ${{ matrix.container }}
+
 strategy:
-  fail-fast: false
   matrix:
     container:
       - debian:latest
       - ubuntu:latest
-
-container: ${{ matrix.container }}
-
-runs-on: ubuntu-latest
+  fail-fast: false
 
 steps:
   - name: Checkout tree

--- a/README.md
+++ b/README.md
@@ -23,15 +23,15 @@ permissions: read-all
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
+
     strategy:
-      fail-fast: false
       matrix:
         os:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-
-    runs-on: ${{ matrix.os }}
+      fail-fast: false
 
     steps:
       - name: Checkout tree
@@ -149,8 +149,8 @@ steps:
 | `opam-disable-sandboxing` | No       | Disable the opam sandboxing feature. opam uses Bubblewrap on Linux and sandbox-exec on macOS. Useful for self-hosted runners where the sandbox tool is not available. On Windows, sandboxing is always disabled.         | bool   | `false`                                                     |
 | `dune-cache`              | No       | Enable Dune build caching via GitHub Actions cache. When enabled, the Dune cache directory is saved and restored between workflow runs to speed up incremental builds.                                                   | bool   | `false`                                                     |
 | `cache-prefix`            | No       | The prefix used for all cache keys. Change this value to force a cache invalidation when the cache becomes corrupted or stale.                                                                                           | string | `v3`                                                        |
-| `windows-environment`     | No       | The Unix environment used for building on Windows. Use `cygwin` (default) for opam's internal Cygwin, or `msys2` to use the pre-installed MSYS2 on GitHub-hosted runners.                                                | string | `cygwin`                                                    |
 | `windows-compiler`        | No       | The C compiler toolchain used for building on Windows. Use `mingw` (default) for mingw-w64 (GCC), or `msvc` for the Microsoft Visual C compiler. MSVC requires Visual Studio (pre-installed on GitHub-hosted runners).   | string | `mingw`                                                     |
+| `windows-environment`     | No       | The Unix environment used for building on Windows. Use `cygwin` (default) for opam's internal Cygwin, or `msys2` to use the pre-installed MSYS2 on GitHub-hosted runners.                                                | string | `cygwin`                                                    |
 | `allow-prerelease-opam`   | No       | Allow the use of a pre-release version of opam. Has no effect when no pre-release version is available.                                                                                                                  | bool   | `false`                                                     |
 
 ### Supported version syntax

--- a/action.yml
+++ b/action.yml
@@ -57,13 +57,6 @@ inputs:
       stale.
     required: false
     default: v3
-  windows-environment:
-    description: >-
-      The Unix environment used for building on Windows.
-      Use "cygwin" (default) for opam's internal Cygwin, or "msys2" to use
-      the pre-installed MSYS2 on GitHub-hosted runners.
-    required: false
-    default: cygwin
   windows-compiler:
     description: >-
       The C compiler toolchain used for building on Windows.
@@ -72,6 +65,13 @@ inputs:
       runner (pre-installed on GitHub-hosted runners).
     required: false
     default: mingw
+  windows-environment:
+    description: >-
+      The Unix environment used for building on Windows.
+      Use "cygwin" (default) for opam's internal Cygwin, or "msys2" to use
+      the pre-installed MSYS2 on GitHub-hosted runners.
+    required: false
+    default: cygwin
   allow-prerelease-opam:
     description: >-
       Allow the use of a pre-release version of opam. Set to "true" to opt


### PR DESCRIPTION
## Summary

- Split the monolithic `test` job into separate `ubuntu`, `macos`, `windows`, and `container` jobs, each with only the matrix dimensions relevant to that platform
- Reorder workflow keys by concern: identity → dependencies → environment → strategy → steps
- Reorder `windows-compiler` before `windows-environment` across `action.yml`, `README.md`, and `EXAMPLES.md` for consistency
- Reorder matrix values to place the more notable variant first (e.g. `true` before `false`)