### PR TITLE
Prepare 3.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-ocaml",
-  "version": "3.4.8",
+  "version": "3.5.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Bump version to 3.5.0 for the next release.

## What's new since v3.4.8

### New Features
- Add MSVC compiler support on Windows (#1072)
- Add MSYS2 support as an alternative to Cygwin on Windows (#1071)
- Support pre-release compiler version resolution (#1075)
- Add `windows-compiler` and `windows-environment` action inputs

### Improvements
- Switch to opam's --cygwin-internal-install to avoid cygwin.com 403 errors (#1067)
- Stop polluting PATH with Cygwin bin directory on Windows (#1069)
- Include Visual Studio version in MSVC opam cache key (#1077)
- Improve action input descriptions and reorder consistently (#1074)
- Clarify supported version syntax in README (#1068)

### Internal
- Replace Biome, esbuild, and Turborepo with Vite Plus (#1079)
- Refactor setup-ocaml source for maintainability (#1070)
- Adopt ES2025 Iterator Helpers (#1076)
- Remove CodeQL and Dependency Review workflows (#1080)
- Split test jobs by platform (#1081)