### PR TITLE
Prepare 3.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-ocaml",
-  "version": "3.5.0",
+  "version": "3.5.1",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Bump version to 3.5.1 for the next release.

## What's new since v3.5.0

### Bug Fixes
- Restore Cygwin bin on PATH for cygwin environment only (#1085)

### Internal
- Add GitHub release creation to release script