### PR TITLE
Add caching documentation to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,10 +226,6 @@ To stay within GitHub Actions' 10 GB per-repository cache limit, the action auto
 If the cache becomes corrupted or stale, you can delete it using the [GitHub CLI](https://cli.github.com):
 
 ```sh
-# List all caches for the repository
-gh cache list
-
-# Delete all caches
 gh cache delete --all
 ```
 


### PR DESCRIPTION
## Summary

- Add a new **Caching** section to README documenting the opam cache, Dune cache, why project dependencies are intentionally not cached, and how to clear caches using the GitHub CLI
- Remove `cache-prefix` from the documented inputs table in favour of recommending `gh cache delete --all` for cache invalidation

Closes #1025