### PR TITLE
Allow action-managed caching to be disabled

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -99,8 +99,18 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Install dependencies
         run: pacman -Sy --noconfirm bash bubblewrap ca-certificates coreutils curl diffutils gcc git gnupg make nano ncurses patch rsync sudo tar unzip xz
-      - name: Set-up OCaml
+      - name: Set-up OCaml without cache
         uses: ./
         with:
           ocaml-compiler: "5.4"
+          cache: false
+          # Verify that the deprecated input cannot override cache: false.
+          dune-cache: true
+      - name: Ensure caches are disabled
+        run: test -z "${DUNE_CACHE_ROOT:-}"
+      - name: Reuse the local switch without cache
+        uses: ./
+        with:
+          ocaml-compiler: "5.4"
+          cache: false
       - run: opam install ssl

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ steps:
 | `opam-pin`                | No       | Automatically pin local opam packages (matched by `opam-local-packages`) in the opam switch. Set to `false` to skip pinning.                                                                                             | bool   | `true`                                                      |
 | `opam-local-packages`     | No       | A glob pattern matching the local `.opam` files to be pinned when `opam-pin` is enabled. Consult the [`@actions/glob` documentation](https://github.com/actions/toolkit/tree/main/packages/glob) for supported patterns. | string | `*.opam`                                                    |
 | `opam-disable-sandboxing` | No       | Disable the opam sandboxing feature. opam uses Bubblewrap on Linux and sandbox-exec on macOS. Useful for self-hosted runners where the sandbox tool is not available. On Windows, sandboxing is always disabled.         | bool   | `false`                                                     |
-| `dune-cache`              | No       | Enable Dune build caching via GitHub Actions cache. When enabled, the Dune cache directory is saved and restored between workflow runs to speed up incremental builds.                                                   | bool   | `false`                                                     |
+| `cache`                   | No       | Cache the opam root and local switch using GitHub Actions cache. Set to `false` to disable all GitHub Actions cache operations. This does not affect the hosted tool cache.                                              | bool   | `true`                                                      |
 | `windows-compiler`        | No       | The C compiler toolchain used for building on Windows. Use `mingw` (default) for mingw-w64 (GCC), or `msvc` for the Microsoft Visual C compiler. MSVC requires Visual Studio (pre-installed on GitHub-hosted runners).   | string | `mingw`                                                     |
 | `windows-environment`     | No       | The Unix environment used for building on Windows. Use `cygwin` (default) for opam's internal Cygwin, or `msys2` to use the pre-installed MSYS2 on GitHub-hosted runners.                                                | string | `cygwin`                                                    |
 | `allow-prerelease-opam`   | No       | Allow the use of a pre-release version of opam. Has no effect when no pre-release version is available.                                                                                                                  | bool   | `false`                                                     |
@@ -182,6 +182,11 @@ Examples:
 
 This action automatically caches the opam root and the local switch (`_opam`) using the GitHub Actions cache. When the cache is hit, the compiler installation is skipped and only `opam update` is run to ensure the repository metadata stays current. This significantly reduces setup time whilst keeping dependency resolution up to date.
 
+Set `cache: false` to disable all GitHub Actions cache operations performed by this action. The hosted tool cache used for the opam executable remains enabled. This can be useful when restoring `_opam` before this action with a custom cache key. If a local switch already exists, the action reuses it instead of creating a new one.
+
+> [!WARNING]
+> Caching a switch after installing project dependencies can consume substantial cache space and may reuse stale or broken packages. If you manage this cache yourself, use an exact compiler version, include the platform, compiler and lock file in the cache key, then run `opam install . --deps-only --locked` after setup. Custom opam caches are used at your own risk; see [#1098](https://github.com/ocaml/setup-ocaml/issues/1098) for the trade-offs and examples.
+
 The cache key is computed from the following components:
 
 - Platform (Linux, macOS, or Windows)
@@ -203,23 +208,6 @@ On Windows, the following additional components are included:
 This action intentionally does not cache the results of `opam install . --deps-only`. Unlike package managers such as npm or Cargo, opam does not use a lock file by default — dependency versions are resolved against the current state of opam-repository at install time.
 
 If these resolved dependencies were cached, opam-repository updates (bug fixes, security patches, new package versions) would not be picked up for as long as the cache remains valid. On active repositories where CI runs frequently, the cache would be hit continuously and never expire, effectively freezing dependencies indefinitely. This would make CI unreliable, as it could pass with stale dependencies whilst failing on a fresh install.
-
-### Dune cache
-
-Optionally, you can enable Dune's build cache by setting `dune-cache: true`. This caches incremental build artefacts to speed up subsequent builds.
-
-The Dune cache key is scoped to the following components:
-
-- Platform
-- Architecture
-- OCaml compiler version
-- Workflow name
-- Job name
-- Run ID
-
-When restoring, the action falls back to partial key matches, so a cache from a previous run of the same workflow and job can be reused.
-
-To stay within GitHub Actions' 10 GB per-repository cache limit, the action automatically trims the Dune cache by dividing a 5 GB budget equally amongst all the jobs in the workflow run.
 
 ### Clearing the cache
 

--- a/action.yml
+++ b/action.yml
@@ -43,13 +43,24 @@ inputs:
       sandboxing is always disabled regardless of this setting.
     required: false
     default: "false"
+  cache:
+    description: >-
+      Cache the opam root and local switch using GitHub Actions cache.
+      Set to "false" to disable all GitHub Actions cache operations, including
+      the deprecated Dune cache. This does not affect the hosted tool cache.
+    required: false
+    default: "true"
   dune-cache:
     description: >-
-      Enable Dune build caching via GitHub Actions cache. When enabled,
-      the Dune cache directory is saved and restored between workflow runs
-      to speed up incremental builds.
+      Deprecated. Enable Dune build caching via GitHub Actions cache. This has
+      no effect when "cache" is "false" and will be removed in the next major
+      release.
     required: false
     default: "false"
+    deprecationMessage: >-
+      This input will be removed in v4. The "cache" input takes precedence:
+      "cache: false" disables Dune caching. Manage Dune caching separately
+      after removal.
   cache-prefix:
     description: >-
       The prefix used for all cache keys. Change this value

--- a/dist/dune.mjs
+++ b/dist/dune.mjs
@@ -88556,7 +88556,8 @@ const OPAM_REPOSITORIES = (() => {
 const OPAM_PIN = getBooleanInput("opam-pin");
 const OPAM_LOCAL_PACKAGES = getInput("opam-local-packages");
 const OPAM_DISABLE_SANDBOXING = PLATFORM !== "windows" && getBooleanInput("opam-disable-sandboxing");
-const DUNE_CACHE = getBooleanInput("dune-cache");
+const OPAM_CACHE = getBooleanInput("cache");
+const DUNE_CACHE = OPAM_CACHE && getBooleanInput("dune-cache");
 const CACHE_PREFIX = getInput("cache-prefix");
 const WINDOWS_ENVIRONMENT = (() => {
 	const value = getInput("windows-environment").toLowerCase();
@@ -90677,4 +90678,4 @@ async function trimDuneCache() {
 }
 
 //#endregion
-export { exec$17 as A, WINDOWS_ENVIRONMENT as C, exportVariable as D, error as E, group as O, PLATFORM as S, debug as T, DUNE_CACHE_ROOT as _, saveDuneCache as a, OPAM_REPOSITORIES as b, installOcaml as c, repositoryRemoveAll as d, setupOpam as f, DUNE_CACHE as g, CYGWIN_ROOT_BIN as h, restoreOpamCache as i, isDebug as k, pin as l, CYGWIN_BASH_ENV as m, trimDuneCache as n, saveOpamCache as o, update as p, restoreDuneCache as r, resolvedCompiler as s, installDune as t, repositoryAddAll as u, OPAM_LOCAL_PACKAGES as v, addPath as w, OPAM_ROOT as x, OPAM_PIN as y };
+export { group as A, OPAM_ROOT as C, debug as D, addPath as E, exec$17 as M, error as O, OPAM_REPOSITORIES as S, WINDOWS_ENVIRONMENT as T, DUNE_CACHE_ROOT as _, saveDuneCache as a, OPAM_LOCAL_PACKAGES as b, installOcaml as c, repositoryRemoveAll as d, setupOpam as f, DUNE_CACHE as g, CYGWIN_ROOT_BIN as h, restoreOpamCache as i, isDebug as j, exportVariable as k, pin as l, CYGWIN_BASH_ENV as m, trimDuneCache as n, saveOpamCache as o, update as p, restoreDuneCache as r, resolvedCompiler as s, installDune as t, repositoryAddAll as u, GITHUB_WORKSPACE as v, PLATFORM as w, OPAM_PIN as x, OPAM_CACHE as y };

--- a/dist/index.mjs
+++ b/dist/index.mjs
@@ -1,4 +1,4 @@
-import { A as exec, C as WINDOWS_ENVIRONMENT, D as exportVariable, E as error, O as group, S as PLATFORM, T as debug, _ as DUNE_CACHE_ROOT, b as OPAM_REPOSITORIES, c as installOcaml, d as repositoryRemoveAll, f as setupOpam, g as DUNE_CACHE, h as CYGWIN_ROOT_BIN, i as restoreOpamCache, k as isDebug, l as pin, m as CYGWIN_BASH_ENV, o as saveOpamCache, p as update, r as restoreDuneCache, s as resolvedCompiler, t as installDune, u as repositoryAddAll, v as OPAM_LOCAL_PACKAGES, w as addPath, x as OPAM_ROOT, y as OPAM_PIN } from "./dune.mjs";
+import { A as group, C as OPAM_ROOT, D as debug, E as addPath, M as exec, O as error, S as OPAM_REPOSITORIES, T as WINDOWS_ENVIRONMENT, _ as DUNE_CACHE_ROOT, b as OPAM_LOCAL_PACKAGES, c as installOcaml, d as repositoryRemoveAll, f as setupOpam, g as DUNE_CACHE, h as CYGWIN_ROOT_BIN, i as restoreOpamCache, j as isDebug, k as exportVariable, l as pin, m as CYGWIN_BASH_ENV, o as saveOpamCache, p as update, r as restoreDuneCache, s as resolvedCompiler, t as installDune, u as repositoryAddAll, v as GITHUB_WORKSPACE, w as PLATFORM, x as OPAM_PIN, y as OPAM_CACHE } from "./dune.mjs";
 import * as process$2 from "node:process";
 import * as os$3 from "os";
 import * as fs$1 from "fs";
@@ -2284,6 +2284,9 @@ function create(patterns, options) {
 //#endregion
 //#region src/installer.ts
 const OPAM_SOLVER_TIMEOUT = 600;
+async function pathExists(filePath) {
+	return await promises$1.access(filePath).then(() => true, () => false);
+}
 async function installer() {
 	if (isDebug()) exportVariable("OPAMVERBOSE", 1);
 	exportVariable("OPAMCOLOR", "always");
@@ -2320,8 +2323,8 @@ async function installer() {
 			]);
 		});
 	}
-	const opamCacheHit = await restoreOpamCache();
-	const opamRootInitialized = await promises$1.access(path.join(OPAM_ROOT, "config")).then(() => true, () => false);
+	const opamCacheHit = OPAM_CACHE ? await restoreOpamCache() : void 0;
+	const [opamRootInitialized, localSwitchInitialized] = await Promise.all([pathExists(path.join(OPAM_ROOT, "config")), pathExists(path.join(GITHUB_WORKSPACE, "_opam", ".opam-switch", "switch-config"))]);
 	const useInitialRepository = !opamCacheHit && !opamRootInitialized;
 	await setupOpam(useInitialRepository ? OPAM_REPOSITORIES[0] : void 0);
 	if (PLATFORM === "windows" && WINDOWS_ENVIRONMENT === "cygwin") {
@@ -2330,14 +2333,16 @@ async function installer() {
 		addPath(CYGWIN_ROOT_BIN);
 	}
 	if (!opamCacheHit) {
-		if (useInitialRepository) await repositoryAddAll(OPAM_REPOSITORIES.slice(1));
+		if (useInitialRepository && !localSwitchInitialized) await repositoryAddAll(OPAM_REPOSITORIES.slice(1));
 		else {
 			await repositoryRemoveAll();
 			await repositoryAddAll(OPAM_REPOSITORIES);
 		}
-		const ocamlCompiler = await resolvedCompiler;
-		await installOcaml(ocamlCompiler);
-		await saveOpamCache();
+		if (!localSwitchInitialized) {
+			const ocamlCompiler = await resolvedCompiler;
+			await installOcaml(ocamlCompiler);
+			if (OPAM_CACHE) await saveOpamCache();
+		}
 	} else await update();
 	if (DUNE_CACHE) {
 		await restoreDuneCache();

--- a/dist/post/index.mjs
+++ b/dist/post/index.mjs
@@ -1,4 +1,4 @@
-import { E as error, a as saveDuneCache, g as DUNE_CACHE, n as trimDuneCache } from "../dune.mjs";
+import { O as error, a as saveDuneCache, g as DUNE_CACHE, n as trimDuneCache } from "../dune.mjs";
 import * as process$1 from "node:process";
 
 //#region src/post.ts

--- a/packages/setup-ocaml/src/constants.ts
+++ b/packages/setup-ocaml/src/constants.ts
@@ -125,7 +125,9 @@ export const OPAM_DISABLE_SANDBOXING =
   // [TODO] unlock this once sandboxing is supported on Windows
   PLATFORM !== "windows" && core.getBooleanInput("opam-disable-sandboxing");
 
-export const DUNE_CACHE = core.getBooleanInput("dune-cache");
+export const OPAM_CACHE = core.getBooleanInput("cache");
+
+export const DUNE_CACHE = OPAM_CACHE && core.getBooleanInput("dune-cache");
 
 export const CACHE_PREFIX = core.getInput("cache-prefix");
 

--- a/packages/setup-ocaml/src/installer.ts
+++ b/packages/setup-ocaml/src/installer.ts
@@ -11,6 +11,8 @@ import {
   CYGWIN_ROOT_BIN,
   DUNE_CACHE,
   DUNE_CACHE_ROOT,
+  GITHUB_WORKSPACE,
+  OPAM_CACHE,
   OPAM_LOCAL_PACKAGES,
   OPAM_PIN,
   OPAM_REPOSITORIES,
@@ -31,6 +33,13 @@ import { resolvedCompiler } from "./version.js";
 
 // 10 minutes — the 0install solver can be slow on large dependency trees.
 const OPAM_SOLVER_TIMEOUT = 600;
+
+async function pathExists(filePath: string) {
+  return await fs.access(filePath).then(
+    () => true,
+    () => false,
+  );
+}
 
 export async function installer() {
   if (core.isDebug()) {
@@ -66,11 +75,11 @@ export async function installer() {
       await exec("fsutil", ["behavior", "query", "SymlinkEvaluation"]);
     });
   }
-  const opamCacheHit = await restoreOpamCache();
-  const opamRootInitialized = await fs.access(path.join(OPAM_ROOT, "config")).then(
-    () => true,
-    () => false,
-  );
+  const opamCacheHit = OPAM_CACHE ? await restoreOpamCache() : undefined;
+  const [opamRootInitialized, localSwitchInitialized] = await Promise.all([
+    pathExists(path.join(OPAM_ROOT, "config")),
+    pathExists(path.join(GITHUB_WORKSPACE, "_opam", ".opam-switch", "switch-config")),
+  ]);
   const useInitialRepository = !opamCacheHit && !opamRootInitialized;
   await setupOpam(useInitialRepository ? OPAM_REPOSITORIES[0] : undefined);
   if (PLATFORM === "windows" && WINDOWS_ENVIRONMENT === "cygwin") {
@@ -79,15 +88,19 @@ export async function installer() {
     core.addPath(CYGWIN_ROOT_BIN);
   }
   if (!opamCacheHit) {
-    if (useInitialRepository) {
+    if (useInitialRepository && !localSwitchInitialized) {
       await repositoryAddAll(OPAM_REPOSITORIES.slice(1));
     } else {
       await repositoryRemoveAll();
       await repositoryAddAll(OPAM_REPOSITORIES);
     }
-    const ocamlCompiler = await resolvedCompiler;
-    await installOcaml(ocamlCompiler);
-    await saveOpamCache();
+    if (!localSwitchInitialized) {
+      const ocamlCompiler = await resolvedCompiler;
+      await installOcaml(ocamlCompiler);
+      if (OPAM_CACHE) {
+        await saveOpamCache();
+      }
+    }
   } else {
     await update();
   }


### PR DESCRIPTION
## Summary

This adds an opt-out for projects that deliberately manage their own opam switch cache, including lock-file-keyed workflows discussed in #1098. Caching remains enabled by default, and the hosted tool cache is unaffected.

- Add a boolean `cache` input to control GitHub Actions caching for the opam root and local switch.
- Reuse an existing local switch when action-managed caching is disabled, leaving switch validation to opam.
- Make `cache: false` override `dune-cache`, deprecate `dune-cache` for removal in v4, and remove it from the documentation.
- Document the risks of custom dependency caching and add CI coverage for the cache-disabled path.

## Testing

- `yarn lint`
- `yarn typecheck`
- `yarn knip`
- Production build and generated-bundle reproducibility checks
- Node.js syntax checks for generated bundles
- `actionlint`

Closes #1098
