### PR TITLE
Bump CI and docs to OCaml 5.5

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -43,10 +43,10 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set-up OCaml 5.4
+      - name: Set-up OCaml 5.5
         uses: ./
         with:
-          ocaml-compiler: "5.4"
+          ocaml-compiler: "5.5"
           allow-prerelease-opam: ${{ matrix.allow-prerelease-opam }}
       - run: opam install ssl
 
@@ -57,10 +57,10 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set-up OCaml 5.4
+      - name: Set-up OCaml 5.5
         uses: ./
         with:
-          ocaml-compiler: "5.4"
+          ocaml-compiler: "5.5"
       - run: opam install ssl
 
   windows:
@@ -79,10 +79,10 @@ jobs:
     steps:
       - name: Checkout tree
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Set-up OCaml 5.4
+      - name: Set-up OCaml 5.5
         uses: ./
         with:
-          ocaml-compiler: "5.4"
+          ocaml-compiler: "5.5"
           windows-compiler: ${{ matrix.windows-compiler }}
           windows-environment: ${{ matrix.windows-environment }}
       - run: opam install ssl
@@ -102,7 +102,7 @@ jobs:
       - name: Set-up OCaml without cache
         uses: ./
         with:
-          ocaml-compiler: "5.4"
+          ocaml-compiler: "5.5"
           cache: false
           # Verify that the deprecated input cannot override cache: false.
           dune-cache: true
@@ -111,6 +111,6 @@ jobs:
       - name: Reuse the local switch without cache
         uses: ./
         with:
-          ocaml-compiler: "5.4"
+          ocaml-compiler: "5.5"
           cache: false
       - run: opam install ssl

--- a/EXAMPLES.md
+++ b/EXAMPLES.md
@@ -89,7 +89,7 @@ steps:
   - name: Set-up OCaml with MSVC
     uses: ocaml/setup-ocaml@v3
     with:
-      ocaml-compiler: "5.4"
+      ocaml-compiler: "5.5"
       windows-compiler: msvc
 ```
 
@@ -105,7 +105,7 @@ steps:
   - name: Set-up OCaml with MSYS2
     uses: ocaml/setup-ocaml@v3
     with:
-      ocaml-compiler: "5.4"
+      ocaml-compiler: "5.5"
       windows-environment: msys2
 ```
 
@@ -121,7 +121,7 @@ steps:
   - name: Set-up OCaml
     uses: ocaml/setup-ocaml@v3
     with:
-      ocaml-compiler: ocaml-base-compiler.5.4.0~dev
+      ocaml-compiler: ocaml-base-compiler.5.5.0~dev
       opam-repositories: |
         custom: git+https://github.com/<username>/<custom-opam-repository>.git
         default: git+https://github.com/ocaml/opam-repository.git
@@ -139,7 +139,7 @@ steps:
   - name: Set-up OCaml
     uses: ocaml/setup-ocaml@v3
     with:
-      ocaml-compiler: "5.4"
+      ocaml-compiler: "5.5"
     env:
       OPAMLOCKED: locked
 

--- a/README.md
+++ b/README.md
@@ -156,13 +156,13 @@ steps:
 
 The `ocaml-compiler` input supports the Semantic Versioning Specification, for more detailed examples please refer to the [documentation](https://github.com/npm/node-semver#ranges).
 
-When a version range is used (e.g., `5`, `5.4.x`), the highest matching version from the opam-repository is always selected.
+When a version range is used (e.g., `5`, `5.5.x`), the highest matching version from the opam-repository is always selected.
 
 > [!WARNING]
 > Version numbers containing a dot **must be quoted** in YAML to avoid being parsed as floats. For example, an unquoted `5.10` is parsed as the float `5.1`, which would silently resolve to the latest `5.1.x` compiler instead of `5.10.x`. To be safe, always quote version values:
 >
 > ```yml
-> ocaml-compiler: "5.4"
+> ocaml-compiler: "5.5"
 > ```
 
 > [!NOTE]
@@ -170,11 +170,11 @@ When a version range is used (e.g., `5`, `5.4.x`), the highest matching version 
 
 Examples:
 
-- Exact package name: `ocaml-base-compiler.5.4.0`
-- Combine multiple packages: `ocaml-variants.5.4.0+options,ocaml-option-flambda,ocaml-option-musl,ocaml-option-static`
+- Exact package name: `ocaml-base-compiler.5.5.0`
+- Combine multiple packages: `ocaml-variants.5.5.0+options,ocaml-option-flambda,ocaml-option-musl,ocaml-option-static`
 - Major versions: `"4"`, `"5"`
-- Minor versions: `"4.08"`, `"4.14"`, `"5.4"`, `"5.4.x"`
-- More specific versions: `"~4.02.2"`, `"5.4.0"`
+- Minor versions: `"4.08"`, `"4.14"`, `"5.5"`, `"5.5.x"`
+- More specific versions: `"~4.02.2"`, `"5.5.0"`
 
 ## Caching
 

--- a/action.yml
+++ b/action.yml
@@ -8,9 +8,9 @@ inputs:
   ocaml-compiler:
     description: >-
       The OCaml compiler packages to initialise. Accepts a semver version
-      range (e.g. "5.3", "4.14.x") which is resolved to the latest
+      range (e.g. "5.5", "4.14.x") which is resolved to the latest
       matching version from opam-repository, or a full opam package name
-      (e.g. "ocaml-variants.5.3.0+options,ocaml-option-flambda").
+      (e.g. "ocaml-variants.5.5.0+options,ocaml-option-flambda").
     required: true
   opam-repositories:
     description: >-

--- a/packages/setup-ocaml/src/version.ts
+++ b/packages/setup-ocaml/src/version.ts
@@ -17,7 +17,7 @@ function parseCompilerVersion(packagePath: string): readonly [string, string] | 
     parsed.major < 5 && parsed.minor < 10
       ? // ocaml-base-compiler.4.00.0, ocaml-base-compiler.4.01.0
         `0${parsed.minor}`
-      : // ocaml-base-compiler.5.4.0, ocaml-base-compiler.4.14.2
+      : // ocaml-base-compiler.5.5.0, ocaml-base-compiler.4.14.2
         parsed.minor;
   const prerelease = parsed.prerelease.length > 0 ? `-${parsed.prerelease.join(".")}` : "";
   const semverVersion = `${parsed.major}.${minor}.${parsed.patch}${prerelease}`;


### PR DESCRIPTION
## Summary

- test the action with OCaml 5.5 across Ubuntu, macOS, Windows, and the container job
- update the README, examples, and action metadata to use OCaml 5.5
- refresh the compiler version example in the version parser

## Testing

- `yarn build`
- `yarn lint`
- `yarn typecheck`
- `yarn knip`