### PR TITLE
Prepare 3.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "setup-ocaml",
-  "version": "3.7.2",
+  "version": "3.8.0",
   "private": true,
   "workspaces": [
     "packages/*"


### PR DESCRIPTION
## Summary

Bump version to 3.8.0 for the next release.

## Changes since v3.7.2

### Features

- Allow action-managed caching to be disabled and reuse existing local switches when caching is disabled (#1125)

### Improvements

- Validate opam output, repository mappings, and runner environment values with Zod (#1128)
- Update CI, documentation, and examples to OCaml 5.5 (#1126)

### Internal

- Add Knip dead-code checks and clean up dependency declarations
- Bump Vite Plus from 0.2.9 to 0.3.0
- Group updates to GitHub Actions maintained by the OCaml organisation (#1127)

## Testing

- `yarn install --immutable`
- `yarn lint`
- `yarn knip`
- `yarn typecheck`
- `yarn build`
